### PR TITLE
removed uneccessary chart component from DesignerHook

### DIFF
--- a/ComponentExample/ce-designer/src/main/java/com/inductiveautomation/ignition/examples/ce/MyModuleDesignerHook.java
+++ b/ComponentExample/ce-designer/src/main/java/com/inductiveautomation/ignition/examples/ce/MyModuleDesignerHook.java
@@ -7,7 +7,6 @@ package com.inductiveautomation.ignition.examples.ce;
 import com.inductiveautomation.ignition.common.licensing.LicenseState;
 import com.inductiveautomation.ignition.designer.model.AbstractDesignerModuleHook;
 import com.inductiveautomation.ignition.designer.model.DesignerContext;
-import com.inductiveautomation.ignition.examples.ce.components.ChartComponent;
 import com.inductiveautomation.ignition.examples.ce.components.HelloWorldComponent;
 import com.inductiveautomation.vision.api.designer.VisionDesignerInterface;
 import com.inductiveautomation.vision.api.designer.palette.JavaBeanPaletteItem;
@@ -35,7 +34,6 @@ public class MyModuleDesignerHook extends AbstractDesignerModuleHook {
 
             PaletteItemGroup group = palette.addGroup("Example");
             group.addPaletteItem(new JavaBeanPaletteItem(HelloWorldComponent.class));
-            group.addPaletteItem(new JavaBeanPaletteItem(ChartComponent.class));
         }
     }
 


### PR DESCRIPTION
A component was being added to the palette which caused unsuccessful build due to missing dependency.  The example doesn't benefit from the additional component, so the component was removed.