### PR TITLE
update release versions ignition 7.9.3, plugin 1.0.12

### DIFF
--- a/AbstractTagDriverExample/atd-build/pom.xml
+++ b/AbstractTagDriverExample/atd-build/pom.xml
@@ -25,7 +25,7 @@
             <plugin>
                 <groupId>com.inductiveautomation.ignitionsdk</groupId>
                 <artifactId>ignition-maven-plugin</artifactId>
-                <version>1.0.5</version>
+                <version>1.0.12</version>
 
                 <executions>
                     <execution>

--- a/AbstractTagDriverExample/atd-gateway/pom.xml
+++ b/AbstractTagDriverExample/atd-gateway/pom.xml
@@ -16,7 +16,7 @@
         <dependency>
             <groupId>com.inductiveautomation.ignitionsdk</groupId>
             <artifactId>ignition-common</artifactId>
-            <version>7.9.0-SNAPSHOT</version>
+            <version>7.9.3</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>com.inductiveautomation.ignitionsdk</groupId>
             <artifactId>gateway-api</artifactId>
-            <version>7.9.0-SNAPSHOT</version>
+            <version>7.9.3</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.inductiveautomation.ignitionsdk</groupId>
             <artifactId>driver-api</artifactId>
-            <version>7.9.0-SNAPSHOT</version>
+            <version>7.9.3</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>

--- a/ComponentExample/ce-build/pom.xml
+++ b/ComponentExample/ce-build/pom.xml
@@ -30,7 +30,7 @@
             <plugin>
                 <groupId>com.inductiveautomation.ignitionsdk</groupId>
                 <artifactId>ignition-maven-plugin</artifactId>
-                <version>1.0.5</version>
+                <version>1.0.12</version>
 
                 <executions>
                     <execution>

--- a/ComponentExample/ce-client/pom.xml
+++ b/ComponentExample/ce-client/pom.xml
@@ -16,7 +16,7 @@
         <dependency>
             <groupId>com.inductiveautomation.ignitionsdk</groupId>
             <artifactId>ignition-common</artifactId>
-            <version>7.9.0-SNAPSHOT</version>
+            <version>7.9.3</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>com.inductiveautomation.ignitionsdk</groupId>
             <artifactId>client-api</artifactId>
-            <version>7.9.0-SNAPSHOT</version>
+            <version>7.9.3</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.inductiveautomation.ignitionsdk</groupId>
             <artifactId>designer-api</artifactId>
-            <version>7.9.0-SNAPSHOT</version>
+            <version>7.9.3</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>com.inductiveautomation.ignitionsdk</groupId>
             <artifactId>vision-designer-api</artifactId>
-            <version>7.9.0-SNAPSHOT</version>
+            <version>7.9.3</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>com.inductiveautomation.ignitionsdk</groupId>
             <artifactId>vision-client-api</artifactId>
-            <version>7.9.0-SNAPSHOT</version>
+            <version>7.9.3</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>

--- a/ComponentExample/ce-designer/pom.xml
+++ b/ComponentExample/ce-designer/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>com.inductiveautomation.ignitionsdk</groupId>
             <artifactId>ignition-common</artifactId>
-            <version>7.9.0-SNAPSHOT</version>
+            <version>7.9.3</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>com.inductiveautomation.ignitionsdk</groupId>
             <artifactId>client-api</artifactId>
-            <version>7.9.0-SNAPSHOT</version>
+            <version>7.9.3</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>com.inductiveautomation.ignitionsdk</groupId>
             <artifactId>designer-api</artifactId>
-            <version>7.9.0-SNAPSHOT</version>
+            <version>7.9.3</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>com.inductiveautomation.ignitionsdk</groupId>
             <artifactId>vision-designer-api</artifactId>
-            <version>7.9.0-SNAPSHOT</version>
+            <version>7.9.3</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>

--- a/ComponentExample/client-launcher/pom.xml
+++ b/ComponentExample/client-launcher/pom.xml
@@ -15,12 +15,12 @@
         <dependency>
             <groupId>com.inductiveautomation.ignitionsdk</groupId>
             <artifactId>client-api</artifactId>
-            <version>7.9.0-SNAPSHOT</version>
+            <version>7.9.3</version>
         </dependency>
         <dependency>
             <groupId>com.inductiveautomation.ignitionsdk</groupId>
             <artifactId>vision-client-api</artifactId>
-            <version>7.9.0-SNAPSHOT</version>
+            <version>7.9.3</version>
         </dependency>
 
         <dependency>

--- a/ComponentExample/designer-launcher/pom.xml
+++ b/ComponentExample/designer-launcher/pom.xml
@@ -15,12 +15,12 @@
         <dependency>
             <groupId>com.inductiveautomation.ignitionsdk</groupId>
             <artifactId>designer-api</artifactId>
-            <version>7.9.0-SNAPSHOT</version>
+            <version>7.9.3</version>
         </dependency>
         <dependency>
             <groupId>com.inductiveautomation.ignitionsdk</groupId>
             <artifactId>vision-designer-api</artifactId>
-            <version>7.9.0-SNAPSHOT</version>
+            <version>7.9.3</version>
         </dependency>
 
         <dependency>

--- a/ModbusDriverExample/mde-build/pom.xml
+++ b/ModbusDriverExample/mde-build/pom.xml
@@ -26,7 +26,7 @@
 
                 <groupId>com.inductiveautomation.ignitionsdk</groupId>
                 <artifactId>ignition-maven-plugin</artifactId>
-                <version>1.0.5</version>
+                <version>1.0.12</version>
 
                 <executions>
                     <execution>

--- a/ModbusDriverExample/mde-gateway/pom.xml
+++ b/ModbusDriverExample/mde-gateway/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.inductiveautomation.ignitionsdk</groupId>
             <artifactId>ignition-common</artifactId>
-            <version>7.9.0-SNAPSHOT</version>
+            <version>7.9.3</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>com.inductiveautomation.ignitionsdk</groupId>
             <artifactId>gateway-api</artifactId>
-            <version>7.9.0-SNAPSHOT</version>
+            <version>7.9.3</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>com.inductiveautomation.ignitionsdk</groupId>
             <artifactId>driver-api</artifactId>
-            <version>7.9.0-SNAPSHOT</version>
+            <version>7.9.3</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>

--- a/NotificationExample/ne-build/pom.xml
+++ b/NotificationExample/ne-build/pom.xml
@@ -35,7 +35,7 @@
 
                 <groupId>com.inductiveautomation.ignitionsdk</groupId>
                 <artifactId>ignition-maven-plugin</artifactId>
-                <version>1.0.4</version>
+                <version>1.0.12</version>
 
                 <executions>
                     <execution>

--- a/NotificationExample/ne-gateway/pom.xml
+++ b/NotificationExample/ne-gateway/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.inductiveautomation.ignitionsdk</groupId>
             <artifactId>ignition-common</artifactId>
-            <version>7.9.0-SNAPSHOT</version>
+            <version>7.9.3</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>com.inductiveautomation.ignitionsdk</groupId>
             <artifactId>gateway-api</artifactId>
-            <version>7.9.0-SNAPSHOT</version>
+            <version>7.9.3</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>com.inductiveautomation.ignitionsdk</groupId>
             <artifactId>alarm-notification-common</artifactId>
-            <version>7.9.0-SNAPSHOT</version>
+            <version>7.9.3</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>com.inductiveautomation.ignitionsdk</groupId>
             <artifactId>alarm-notification-gateway-api</artifactId>
-            <version>7.9.0-SNAPSHOT</version>
+            <version>7.9.3</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>

--- a/SimpleTagProviderExample/stp-build/pom.xml
+++ b/SimpleTagProviderExample/stp-build/pom.xml
@@ -26,7 +26,7 @@
             <plugin>
                 <groupId>com.inductiveautomation.ignitionsdk</groupId>
                 <artifactId>ignition-maven-plugin</artifactId>
-                <version>1.0.5</version>
+                <version>1.0.12</version>
 
                 <executions>
                     <execution>

--- a/SimpleTagProviderExample/stp-gateway/pom.xml
+++ b/SimpleTagProviderExample/stp-gateway/pom.xml
@@ -16,7 +16,7 @@
         <dependency>
             <groupId>com.inductiveautomation.ignitionsdk</groupId>
             <artifactId>ignition-common</artifactId>
-            <version>7.9.0-SNAPSHOT</version>
+            <version>7.9.3</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>com.inductiveautomation.ignitionsdk</groupId>
             <artifactId>gateway-api</artifactId>
-            <version>7.9.0-SNAPSHOT</version>
+            <version>7.9.3</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>

--- a/WeatherModuleExample/wme-build/pom.xml
+++ b/WeatherModuleExample/wme-build/pom.xml
@@ -30,7 +30,7 @@
 
                 <groupId>com.inductiveautomation.ignitionsdk</groupId>
                 <artifactId>ignition-maven-plugin</artifactId>
-                <version>1.0.5</version>
+                <version>1.0.12</version>
 
                 <executions>
                     <execution>

--- a/WeatherModuleExample/wme-client/pom.xml
+++ b/WeatherModuleExample/wme-client/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.inductiveautomation.ignitionsdk</groupId>
             <artifactId>ignition-common</artifactId>
-            <version>7.9.0-SNAPSHOT</version>
+            <version>7.9.3</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>com.inductiveautomation.ignitionsdk</groupId>
             <artifactId>vision-common</artifactId>
-            <version>7.9.0-SNAPSHOT</version>
+            <version>7.9.3</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>com.inductiveautomation.ignitionsdk</groupId>
             <artifactId>vision-client-api</artifactId>
-            <version>7.9.0-SNAPSHOT</version>
+            <version>7.9.3</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>

--- a/WeatherModuleExample/wme-designer/pom.xml
+++ b/WeatherModuleExample/wme-designer/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.inductiveautomation.ignitionsdk</groupId>
             <artifactId>ignition-common</artifactId>
-            <version>7.9.0-SNAPSHOT</version>
+            <version>7.9.3</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>com.inductiveautomation.ignitionsdk</groupId>
             <artifactId>designer-api</artifactId>
-            <version>7.9.0-SNAPSHOT</version>
+            <version>7.9.3</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>com.inductiveautomation.ignitionsdk</groupId>
             <artifactId>vision-common</artifactId>
-            <version>7.9.0-SNAPSHOT</version>
+            <version>7.9.3</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>com.inductiveautomation.ignitionsdk</groupId>
             <artifactId>vision-designer-api</artifactId>
-            <version>7.9.0-SNAPSHOT</version>
+            <version>7.9.3</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>

--- a/gateway-network-example/pom.xml
+++ b/gateway-network-example/pom.xml
@@ -13,7 +13,7 @@
     <description>Retrieves log entries from remote Gateways over the Gateway Network</description>
 
     <properties>
-        <ignition-sdk-version>7.9.0-SNAPSHOT</ignition-sdk-version>
+        <ignition-sdk-version>7.9.3</ignition-sdk-version>
     </properties>
 
     <modules>

--- a/home-connect-example/hce-build/pom.xml
+++ b/home-connect-example/hce-build/pom.xml
@@ -26,7 +26,7 @@
 
                 <groupId>com.inductiveautomation.ignitionsdk</groupId>
                 <artifactId>ignition-maven-plugin</artifactId>
-                <version>1.0.9</version>
+                <version>1.0.12</version>
 
                 <executions>
                     <execution>

--- a/home-connect-example/hce-gateway/pom.xml
+++ b/home-connect-example/hce-gateway/pom.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>com.inductiveautomation.ignitionsdk</groupId>
             <artifactId>ignition-common</artifactId>
-            <version>7.9.0-SNAPSHOT</version>
+            <version>7.9.3</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>com.inductiveautomation.ignitionsdk</groupId>
             <artifactId>gateway-api</artifactId>
-            <version>7.9.0-SNAPSHOT</version>
+            <version>7.9.3</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>com.inductiveautomation.ignitionsdk</groupId>
             <artifactId>driver-api</artifactId>
-            <version>7.9.0-SNAPSHOT</version>
+            <version>7.9.3</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>

--- a/report-component/build/pom.xml
+++ b/report-component/build/pom.xml
@@ -39,7 +39,7 @@
             <plugin>
                 <groupId>com.inductiveautomation.ignitionsdk</groupId>
                 <artifactId>ignition-maven-plugin</artifactId>
-                <version>1.0.9</version>
+                <version>1.0.12</version>
 
                 <!-- attach our .modl building process to the 'package' maven phase, and our 'post' or 'install to  -->
                 <!-- local developer gateway' goal to the install phase.                                            -->

--- a/report-datasource-example/build/pom.xml
+++ b/report-datasource-example/build/pom.xml
@@ -40,7 +40,7 @@
             <plugin>
                 <groupId>com.inductiveautomation.ignitionsdk</groupId>
                 <artifactId>ignition-maven-plugin</artifactId>
-                <version>1.0.9</version>
+                <version>1.0.12</version>
 
                 <!-- attach our .modl building process to the 'package' maven phase, and our 'post' or 'install to  -->
                 <!-- local developer gateway' goal to the install phase.                                            -->

--- a/report-datasource-example/common/pom.xml
+++ b/report-datasource-example/common/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.inductiveautomation.ignitionsdk</groupId>
             <artifactId>reporting-common</artifactId>
-            <version>7.9.0-SNAPSHOT</version>
+            <version>7.9.3</version>
             <scope>provided</scope>
             <type>pom</type>
         </dependency>

--- a/report-datasource-example/designer/pom.xml
+++ b/report-datasource-example/designer/pom.xml
@@ -16,7 +16,7 @@
         <dependency>
             <groupId>com.inductiveautomation.ignitionsdk</groupId>
             <artifactId>reporting-designer</artifactId>
-            <version>7.9.0-SNAPSHOT</version>
+            <version>7.9.3</version>
             <scope>provided</scope>
             <type>pom</type>
         </dependency>

--- a/report-datasource-example/gateway/pom.xml
+++ b/report-datasource-example/gateway/pom.xml
@@ -17,7 +17,7 @@
             <!-- reporting-gateway dependency provides reporting gateway api -->
             <groupId>com.inductiveautomation.ignitionsdk</groupId>
             <artifactId>reporting-gateway</artifactId>
-            <version>7.9.0-SNAPSHOT</version>
+            <version>7.9.3</version>
             <scope>provided</scope>
             <type>pom</type>
         </dependency>

--- a/scripting-rpc-example/scripting-rpc-build/pom.xml
+++ b/scripting-rpc-example/scripting-rpc-build/pom.xml
@@ -39,7 +39,7 @@
             <plugin>
                 <groupId>com.inductiveautomation.ignitionsdk</groupId>
                 <artifactId>ignition-maven-plugin</artifactId>
-                <version>1.0.9-SNAPSHOT</version>
+                <version>1.0.12</version>
 
                 <executions>
                     <execution>

--- a/scripting-rpc-example/scripting-rpc-client/pom.xml
+++ b/scripting-rpc-example/scripting-rpc-client/pom.xml
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>com.inductiveautomation.ignitionsdk</groupId>
             <artifactId>ignition-common</artifactId>
-            <version>7.9.0-SNAPSHOT</version>
+            <version>7.9.3</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>com.inductiveautomation.ignitionsdk</groupId>
             <artifactId>client-api</artifactId>
-            <version>7.9.0-SNAPSHOT</version>
+            <version>7.9.3</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>com.inductiveautomation.ignitionsdk</groupId>
             <artifactId>designer-api</artifactId>
-            <version>7.9.0-SNAPSHOT</version>
+            <version>7.9.3</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>com.inductiveautomation.ignitionsdk</groupId>
             <artifactId>vision-designer-api</artifactId>
-            <version>7.9.0-SNAPSHOT</version>
+            <version>7.9.3</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>com.inductiveautomation.ignitionsdk</groupId>
             <artifactId>vision-client-api</artifactId>
-            <version>7.9.0-SNAPSHOT</version>
+            <version>7.9.3</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>

--- a/scripting-rpc-example/scripting-rpc-common/pom.xml
+++ b/scripting-rpc-example/scripting-rpc-common/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.inductiveautomation.ignitionsdk</groupId>
             <artifactId>ignition-common</artifactId>
-            <version>7.9.0-SNAPSHOT</version>
+            <version>7.9.3</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>

--- a/scripting-rpc-example/scripting-rpc-designer/pom.xml
+++ b/scripting-rpc-example/scripting-rpc-designer/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>com.inductiveautomation.ignitionsdk</groupId>
             <artifactId>ignition-common</artifactId>
-            <version>7.9.0-SNAPSHOT</version>
+            <version>7.9.3</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>com.inductiveautomation.ignitionsdk</groupId>
             <artifactId>client-api</artifactId>
-            <version>7.9.0-SNAPSHOT</version>
+            <version>7.9.3</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>com.inductiveautomation.ignitionsdk</groupId>
             <artifactId>designer-api</artifactId>
-            <version>7.9.0-SNAPSHOT</version>
+            <version>7.9.3</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>com.inductiveautomation.ignitionsdk</groupId>
             <artifactId>vision-designer-api</artifactId>
-            <version>7.9.0-SNAPSHOT</version>
+            <version>7.9.3</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>

--- a/scripting-rpc-example/scripting-rpc-gateway/pom.xml
+++ b/scripting-rpc-example/scripting-rpc-gateway/pom.xml
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>com.inductiveautomation.ignitionsdk</groupId>
             <artifactId>ignition-common</artifactId>
-            <version>7.9.0-SNAPSHOT</version>
+            <version>7.9.3</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>com.inductiveautomation.ignitionsdk</groupId>
             <artifactId>gateway-api</artifactId>
-            <version>7.9.0-SNAPSHOT</version>
+            <version>7.9.3</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>com.inductiveautomation.ignitionsdk</groupId>
             <artifactId>driver-api</artifactId>
-            <version>7.9.0-SNAPSHOT</version>
+            <version>7.9.3</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>


### PR DESCRIPTION
Updates to the most recently published final release versions, resolving issue where milo 0.1.0-SNAPSHOT won't resolve.

Also updated all `ignition-maven-plugin` dependencies to current version for consistency.