### PR TITLE
Replace deprecated loggers, add example license/docs 

### DIFF
--- a/ModbusDriverExample/mde-build/doc/index.html
+++ b/ModbusDriverExample/mde-build/doc/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html>
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <title>Module User Manual</title>
+</head>
+
+<body>
+    <h1>Instructions</h1>
+
+    <p>This is the root of the Modbus Driver Example Documentation.</p>
+</body>
+</html>

--- a/ModbusDriverExample/mde-build/license.html
+++ b/ModbusDriverExample/mde-build/license.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html>
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <title>Module License</title>
+</head>
+<body>
+    <h1>Example License</h1>
+
+    <p>This is the license for the Modbus driver example module. You must agree to it.</p>
+</body>
+</html>

--- a/ModbusDriverExample/mde-gateway/src/main/java/com/inductiveautomation/xopc/drivers/modbus2/AbstractModbusDriver.java
+++ b/ModbusDriverExample/mde-gateway/src/main/java/com/inductiveautomation/xopc/drivers/modbus2/AbstractModbusDriver.java
@@ -47,6 +47,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import com.inductiveautomation.ignition.common.util.LoggerEx;
 import com.inductiveautomation.opcua.nodes.Node;
 import com.inductiveautomation.opcua.types.AccessLevel;
 import com.inductiveautomation.opcua.types.DataType;
@@ -189,12 +190,12 @@ public abstract class AbstractModbusDriver extends AbstractIODelegatingDriver {
 				settings.isReadMultipleRegistersRequestAllowed(),
 				settings.isReadMultipleCoilsAllowed(),
 				settings.isReadMultipleDiscreteInputsAllowed(),
-				makeSubLogger(ModbusReadOptimizer.class.getSimpleName()));
+				log.createSubLogger(ModbusReadOptimizer.class.getSimpleName()));
 
 		writeOptimizer = new ModbusWriteOptimizer(
 				settings.isWriteMultipleCoilsRequestAllowed(),
 				settings.isWriteMultipleRegistersRequestAllowed(),
-				makeSubLogger(ModbusWriteOptimizer.class.getSimpleName()));
+				log.createSubLogger(ModbusWriteOptimizer.class.getSimpleName()));
 
 		nodeMap.put(ROOT_NODE_ADDRESS, rootNode);
 	}
@@ -217,7 +218,7 @@ public abstract class AbstractModbusDriver extends AbstractIODelegatingDriver {
 	protected List<List<? extends ReadItem>> optimizeRead(List<? extends ReadItem> items) {
 		setModbusAddressObject(items);
 
-		List<List<? extends ReadItem>> optimized = new ArrayList<List<? extends ReadItem>>();
+		List<List<? extends ReadItem>> optimized = new ArrayList<>();
 		optimized.addAll(readOptimizer.optimizeReads((List<ReadItem>) items));
 
 		return optimized;
@@ -228,7 +229,7 @@ public abstract class AbstractModbusDriver extends AbstractIODelegatingDriver {
 	protected List<List<? extends WriteItem>> optimizeWrite(List<? extends WriteItem> items) {
 		setModbusAddressObject(items);
 
-		List<List<? extends WriteItem>> optimized = new ArrayList<List<? extends WriteItem>>();
+		List<List<? extends WriteItem>> optimized = new ArrayList<>();
 		optimized.addAll(writeOptimizer.optimizeWrites((List<WriteItem>) items));
 
 		return optimized;
@@ -271,7 +272,7 @@ public abstract class AbstractModbusDriver extends AbstractIODelegatingDriver {
 
 	@Override
 	protected Request<byte[]> createBrowseRequest(BrowseOperation browseOp) {
-		List<String> results = new ArrayList<String>();
+		List<String> results = new ArrayList<>();
 
 		String address = browseOp.getStartingAddress();
 		if (address == null || address.isEmpty()) {
@@ -360,10 +361,6 @@ public abstract class AbstractModbusDriver extends AbstractIODelegatingDriver {
 	@Override
 	protected boolean isOfflineBrowsingSupported() {
 		return true;
-	}
-
-	private Logger makeSubLogger(String name) {
-		return Logger.getLogger(String.format("%s.%s", log.getName(), name));
 	}
 
 	private void setAddressMap(String addressMap) {

--- a/ModbusDriverExample/mde-gateway/src/main/java/com/inductiveautomation/xopc/drivers/modbus2/ModuleHook.java
+++ b/ModbusDriverExample/mde-gateway/src/main/java/com/inductiveautomation/xopc/drivers/modbus2/ModuleHook.java
@@ -45,7 +45,6 @@ import com.google.common.collect.Lists;
 import com.inductiveautomation.ignition.common.BundleUtil;
 import com.inductiveautomation.ignition.gateway.localdb.DDLSchemaFeature;
 import com.inductiveautomation.ignition.gateway.localdb.SchemaFeature;
-import com.inductiveautomation.ignition.gateway.localdb.persistence.StringField;
 import com.inductiveautomation.ignition.gateway.model.GatewayContext;
 import com.inductiveautomation.xopc.driver.api.configuration.DriverManager;
 import com.inductiveautomation.xopc.driver.api.configuration.DriverType;

--- a/ModbusDriverExample/mde-gateway/src/main/java/com/inductiveautomation/xopc/drivers/modbus2/factories/ReadRequestFactory.java
+++ b/ModbusDriverExample/mde-gateway/src/main/java/com/inductiveautomation/xopc/drivers/modbus2/factories/ReadRequestFactory.java
@@ -40,6 +40,7 @@ package com.inductiveautomation.xopc.drivers.modbus2.factories;
 
 import java.util.List;
 
+import com.inductiveautomation.ignition.common.util.LoggerEx;
 import org.apache.log4j.Logger;
 
 import com.inductiveautomation.xopc.driver.api.items.ReadItem;
@@ -59,20 +60,20 @@ public class ReadRequestFactory {
 	private final ModbusTransportFactory transportFactory;
 	private final boolean zeroBased;
 	private final int timeout;
-	private final Logger log;
+	private final LoggerEx log;
 	private final boolean swapWords;
 	private final boolean reverseStringByteOrder;
 	private final CommunicationCallback communicationCallback;
 
 	public ReadRequestFactory(
-			ChannelWriter channelWriter,
-			ModbusTransportFactory transportFactory,
-			boolean zeroBased,
-			int timeout,
-			Logger log,
-			boolean swapWords,
-			boolean reverseStringByteOrder,
-			CommunicationCallback communicationCallback) {
+        ChannelWriter channelWriter,
+        ModbusTransportFactory transportFactory,
+        boolean zeroBased,
+        int timeout,
+        LoggerEx log,
+        boolean swapWords,
+        boolean reverseStringByteOrder,
+        CommunicationCallback communicationCallback) {
 		this.channelWriter = channelWriter;
 		this.transportFactory = transportFactory;
 		this.zeroBased = zeroBased;

--- a/ModbusDriverExample/mde-gateway/src/main/java/com/inductiveautomation/xopc/drivers/modbus2/factories/WriteRequestFactory.java
+++ b/ModbusDriverExample/mde-gateway/src/main/java/com/inductiveautomation/xopc/drivers/modbus2/factories/WriteRequestFactory.java
@@ -40,6 +40,7 @@ package com.inductiveautomation.xopc.drivers.modbus2.factories;
 
 import java.util.List;
 
+import com.inductiveautomation.ignition.common.util.LoggerEx;
 import org.apache.log4j.Logger;
 
 import com.inductiveautomation.xopc.driver.api.items.WriteItem;
@@ -60,22 +61,22 @@ public class WriteRequestFactory {
 	private final ModbusTransportFactory transportFactory;
 	private final boolean zeroBased;
 	private final int timeout;
-	private final Logger log;
+	private final LoggerEx log;
 	private final boolean swapWords;
 	private final boolean rightJustifyStrings;
 	private final boolean reverseStringByteOrder;
 	private final CommunicationCallback communicationCallback;
 
 	public WriteRequestFactory(
-			ChannelWriter channelWriter,
-			ModbusTransportFactory transportFactory,
-			boolean zeroBased,
-			int timeout,
-			Logger log,
-			boolean swapWords,
-			boolean rightJustifyStrings,
-			boolean reverseStringByteOrder,
-			CommunicationCallback communicationCallback) {
+        ChannelWriter channelWriter,
+        ModbusTransportFactory transportFactory,
+        boolean zeroBased,
+        int timeout,
+        LoggerEx log,
+        boolean swapWords,
+        boolean rightJustifyStrings,
+        boolean reverseStringByteOrder,
+        CommunicationCallback communicationCallback) {
 		this.channelWriter = channelWriter;
 		this.transportFactory = transportFactory;
 		this.zeroBased = zeroBased;

--- a/ModbusDriverExample/mde-gateway/src/main/java/com/inductiveautomation/xopc/drivers/modbus2/requests/optimizer/ModbusReadOptimizer.java
+++ b/ModbusDriverExample/mde-gateway/src/main/java/com/inductiveautomation/xopc/drivers/modbus2/requests/optimizer/ModbusReadOptimizer.java
@@ -38,6 +38,7 @@
  ******************************************************************************/
 package com.inductiveautomation.xopc.drivers.modbus2.requests.optimizer;
 
+import com.inductiveautomation.ignition.common.util.LoggerEx;
 import com.inductiveautomation.xopc.driver.api.items.ReadItem;
 import com.inductiveautomation.xopc.drivers.modbus2.address.ModbusAddress;
 import com.inductiveautomation.xopc.drivers.modbus2.address.ModbusTable;
@@ -64,22 +65,22 @@ public class ModbusReadOptimizer {
 	private boolean readMultipleCoilsAllowed = true;
 	private boolean readMultipleDiscreteInputsAllowed = true;
 
-	private final Logger log;
+	private final LoggerEx log;
 
 	ModbusReadOptimizer() {
-		log = Logger.getLogger(getClass().getSimpleName());
+		log = LoggerEx.newBuilder().build(getClass().getSimpleName());
 	}
 
 	public ModbusReadOptimizer(
-			int maxCoils,
-			int maxDiscreteInputs,
-			int maxHoldingRegisters,
-			int maxInputRegisters,
-			boolean spanGaps,
-			boolean readMultipleRegistersRequestAllowed,
-			boolean readMultipleCoilsAllowed,
-			boolean readMultipleDiscreteInputsAllowed,
-			Logger log) {
+        int maxCoils,
+        int maxDiscreteInputs,
+        int maxHoldingRegisters,
+        int maxInputRegisters,
+        boolean spanGaps,
+        boolean readMultipleRegistersRequestAllowed,
+        boolean readMultipleCoilsAllowed,
+        boolean readMultipleDiscreteInputsAllowed,
+        LoggerEx log) {
 		this.maxCoils = maxCoils;
 		this.maxDiscreteInputs = maxDiscreteInputs;
 		this.maxHoldingRegisters = maxHoldingRegisters;
@@ -102,7 +103,7 @@ public class ModbusReadOptimizer {
 	 * @return Items optimized into lists that will fit into a single {@link com.inductiveautomation.xopc.driver.api.requests.Request}.
 	 */
 	public List<List<ReadItem>> optimizeReads(List<ReadItem> toOptimize) {
-		List<List<ReadItem>> optimized = new ArrayList<List<ReadItem>>();
+		List<List<ReadItem>> optimized = new ArrayList<>();
 
 		long start = System.currentTimeMillis();
 

--- a/ModbusDriverExample/mde-gateway/src/main/java/com/inductiveautomation/xopc/drivers/modbus2/requests/optimizer/ModbusWriteOptimizer.java
+++ b/ModbusDriverExample/mde-gateway/src/main/java/com/inductiveautomation/xopc/drivers/modbus2/requests/optimizer/ModbusWriteOptimizer.java
@@ -43,6 +43,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
+import com.inductiveautomation.ignition.common.util.LoggerEx;
 import org.apache.log4j.Logger;
 
 import com.google.common.base.Predicate;
@@ -77,16 +78,16 @@ public class ModbusWriteOptimizer {
 	private boolean writeMultipleCoilsRequestAllowed = true;
 	private boolean writeMultipleRegistersRequestAllowed = true;
 
-	private final Logger log;
+	private final LoggerEx log;
 
 	ModbusWriteOptimizer() {
-		log = Logger.getLogger(getClass().getSimpleName());
+		log = LoggerEx.newBuilder().build(getClass().getSimpleName());
 	}
 
 	public ModbusWriteOptimizer(
 			boolean writeMultipleCoilsRequestAllowed,
 			boolean writeMultipleRegistersRequestAllowed,
-			Logger log) {
+			LoggerEx log) {
 		this.writeMultipleCoilsRequestAllowed = writeMultipleCoilsRequestAllowed;
 		this.writeMultipleRegistersRequestAllowed = writeMultipleRegistersRequestAllowed;
 		this.log = log;

--- a/ModbusDriverExample/mde-gateway/src/test/java/com/inductiveautomation/xopc/drivers/modbus2/requests/optimizer/ModbusReadOptimizerTest.java
+++ b/ModbusDriverExample/mde-gateway/src/test/java/com/inductiveautomation/xopc/drivers/modbus2/requests/optimizer/ModbusReadOptimizerTest.java
@@ -43,6 +43,7 @@ import static org.junit.Assert.assertEquals;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.inductiveautomation.ignition.common.util.LoggerEx;
 import com.inductiveautomation.opcua.types.DataValue;
 import com.inductiveautomation.opcua.types.NodeId;
 import com.inductiveautomation.xopc.driver.api.items.ReadItem;
@@ -125,7 +126,7 @@ public class ModbusReadOptimizerTest {
 		}
 
 		ModbusReadOptimizer optimizer = new ModbusReadOptimizer(1000, 2000, 125, 125, true, true, true, true,
-																Logger.getLogger("testCustomMaxCoils()"));
+																LoggerEx.newBuilder().build("testCustomMaxCoils()"));
 		List<List<ReadItem>> optimized = optimizer.optimizeReads(items);
 
 		assertEquals("Should have been optimized into 4 requests.", 4, optimized.size());
@@ -182,7 +183,7 @@ public class ModbusReadOptimizerTest {
 		items.add(new TestReadItem(addr4));
 
 		ModbusReadOptimizer optimizer = new ModbusReadOptimizer(2000, 2000, 125, 125, false, true, true, true,
-																Logger.getLogger("testGapSpanningOff"));
+																LoggerEx.newBuilder().build("testGapSpanningOff"));
 		List<List<ReadItem>> optimized = optimizer.optimizeReads(items);
 
 		assertEquals("Should have been optimized into 3 requests.", 3, optimized.size());


### PR DESCRIPTION
... to Modbus driver example.  

Got a report that the module wasn't building based on the latest sdk.  Seemed issues related to Logger being used and missing docs/license.  Updated to LoggerEx, and did a little java 8 cleanup while there.  Also added doc/license examples as they were specified in the module config, but weren't actually present which resulted in errors during `mvn package`.