### PR TITLE
Add license and doc files to Weather Module Example

### DIFF
--- a/WeatherModuleExample/wme-build/doc/index.html
+++ b/WeatherModuleExample/wme-build/doc/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html>
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <title>Module User Manual</title>
+</head>
+<body>
+<h1>Instructions</h1>
+
+<p>This is the root of the WeatherModule user manual.</p>
+</body>
+</html>

--- a/WeatherModuleExample/wme-build/license.html
+++ b/WeatherModuleExample/wme-build/license.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html>
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <title>Module License</title>
+</head>
+<body>
+<h1>Example License</h1>
+
+<p>This is the license for the WeatherModule. You must agree to it.</p>
+</body>
+</html>


### PR DESCRIPTION
Feedback from ModuleDev workshop: weather module example wasn't building because pom.xml references a missing license file. Added license and doc examples to fix this.