### PR TITLE
Replace method to all building for 8

### DIFF
--- a/managed-tag-provider/managed-tag-provider-gateway/src/main/java/com/inductiveautomation/ignition/examples/mtp/ManagedProviderGatewayHook.java
+++ b/managed-tag-provider/managed-tag-provider-gateway/src/main/java/com/inductiveautomation/ignition/examples/mtp/ManagedProviderGatewayHook.java
@@ -51,7 +51,7 @@ public class ManagedProviderGatewayHook extends AbstractGatewayModuleHook {
             configuration.setAllowTagCustomization(true);
             configuration.setPersistTags(false);
             configuration.setPersistValues(false);
-            configuration.setMetaFlag(TagProviderMeta.FLAG_HAS_OPCBROWSE, false);
+            configuration.setAttribute(TagProviderMeta.FLAG_HAS_OPCBROWSE, false);
 
             ourProvider = context.getTagManager().getOrCreateManagedProvider(configuration);
             //Set up the control tag.


### PR DESCRIPTION
Resolves a missing symbol in 8 to allow the managed-tag-provider module to be built by replacing setMetaFlag with setAttribute