### PR TITLE
Make sure config categories line up with the menu structure

### DIFF
--- a/gateway-webpage/gateway-webpage-gateway/src/main/java/com/inductiveautomation/ignition/examples/hce/GatewayHook.java
+++ b/gateway-webpage/gateway-webpage-gateway/src/main/java/com/inductiveautomation/ignition/examples/hce/GatewayHook.java
@@ -45,7 +45,6 @@ import org.apache.wicket.protocol.http.WebApplication;
  *
  */
 public class GatewayHook extends AbstractGatewayModuleHook {
-    private static final String[] HCON_MENU_PATH = {"homeconnect"};
     private GatewayContext context;
 
     private final LoggerEx log = LogUtil.getLogger(getClass().getSimpleName());
@@ -75,7 +74,8 @@ public class GatewayHook extends AbstractGatewayModuleHook {
     /**
      * This sets up the config panel
      */
-    public static final ConfigCategory CONFIG_CATEGORY = new ConfigCategory("hce", "HomeConnect.nav.header", 700);
+    public static final ConfigCategory CONFIG_CATEGORY =
+        new ConfigCategory("HomeConnect", "HomeConnect.nav.header", 700);
 
     @Override
     public List<ConfigCategory> getConfigCategories() {
@@ -84,7 +84,7 @@ public class GatewayHook extends AbstractGatewayModuleHook {
 
     public static final IConfigTab HCE_CONFIG_ENTRY = DefaultConfigTab.builder()
             .category(CONFIG_CATEGORY)
-            .name("hub")
+            .name("homeconnect")
             .i18n("HomeConnect.nav.settings.title")
             .page(HCSettingsPage.class)
             .terms("home connect settings")

--- a/gateway-webpage/gateway-webpage-gateway/src/main/java/com/inductiveautomation/ignition/examples/hce/web/HCSettingsPage.java
+++ b/gateway-webpage/gateway-webpage-gateway/src/main/java/com/inductiveautomation/ignition/examples/hce/web/HCSettingsPage.java
@@ -1,13 +1,13 @@
 package com.inductiveautomation.ignition.examples.hce.web;
 
+import com.inductiveautomation.ignition.examples.hce.GatewayHook;
 import com.inductiveautomation.ignition.examples.hce.records.HCSettingsRecord;
-import com.inductiveautomation.ignition.gateway.model.GatewayContext;
 import com.inductiveautomation.ignition.gateway.model.IgnitionWebApp;
 import com.inductiveautomation.ignition.gateway.web.components.RecordEditForm;
 import com.inductiveautomation.ignition.gateway.web.models.LenientResourceModel;
 import com.inductiveautomation.ignition.gateway.web.pages.IConfigPage;
-import org.apache.wicket.Application;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.wicket.Application;
 
 /**
  * Filename: HCSettingsPage
@@ -18,7 +18,8 @@ import org.apache.commons.lang3.tuple.Pair;
  * HCSettings extends  {@link RecordEditForm} to provide a page where we can edit records in our PersistentRecord.
  */
 public class HCSettingsPage extends RecordEditForm {
-    public static final String[] PATH = {"homeconnect", "settings"};
+    public static final Pair<String, String> MENU_LOCATION =
+        Pair.of(GatewayHook.CONFIG_CATEGORY.getName(), "homeconnect");
 
     public HCSettingsPage(final IConfigPage configPage) {
         super(configPage, null, new LenientResourceModel("HomeConnect.nav.settings.panelTitle"),
@@ -29,7 +30,7 @@ public class HCSettingsPage extends RecordEditForm {
 
     @Override
     public Pair<String, String> getMenuLocation() {
-        return Pair.of("homeconnect", "settings");
+        return MENU_LOCATION;
     }
 
 }


### PR DESCRIPTION
This fixes the missing breadcrumb entry for the Gateway config page. Also fixes the lack of highlighting the current page in the left-hand nav menu.