### PR TITLE
Update device example for Ignition 8.0.13

### DIFF
--- a/opc-ua-device/opc-ua-device-gateway/pom.xml
+++ b/opc-ua-device/opc-ua-device-gateway/pom.xml
@@ -34,6 +34,12 @@
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.2</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/opc-ua-device/opc-ua-device-gateway/src/main/java/com/inductiveautomation/ignition/examples/tagdriver/ExampleDevice.java
+++ b/opc-ua-device/opc-ua-device-gateway/src/main/java/com/inductiveautomation/ignition/examples/tagdriver/ExampleDevice.java
@@ -93,6 +93,8 @@ public class ExampleDevice extends ManagedAddressSpaceServices implements Device
 
         addDynamicNodes(rootNode);
 
+        subscriptionModel.startup();
+
         // fire initial subscription creation
         List<DataItem> dataItems = deviceContext.getSubscriptionModel().getDataItems(getName());
         onDataItemsCreated(dataItems);
@@ -100,7 +102,9 @@ public class ExampleDevice extends ManagedAddressSpaceServices implements Device
 
     @Override
     public void onShutdown() {
-        super.getNodeContext();
+        super.onShutdown();
+
+        subscriptionModel.shutdown();
 
         deviceContext.getGatewayContext()
             .getExecutionManager()

--- a/opc-ua-device/pom.xml
+++ b/opc-ua-device/pom.xml
@@ -15,7 +15,7 @@
     </modules>
 
     <properties>
-        <ignition-platform-version>8.0.0</ignition-platform-version>
+        <ignition-platform-version>8.0.13-SNAPSHOT</ignition-platform-version>
         <ignition-sdk-version>${ignition-platform-version}</ignition-sdk-version>
         <module-name>OPC UA Device Example</module-name>
         <module-description>Shows how to implement a new OPC UA device type</module-description>

--- a/opc-ua-device/pom.xml
+++ b/opc-ua-device/pom.xml
@@ -15,7 +15,7 @@
     </modules>
 
     <properties>
-        <ignition-platform-version>8.0.13-SNAPSHOT</ignition-platform-version>
+        <ignition-platform-version>8.0.13</ignition-platform-version>
         <ignition-sdk-version>${ignition-platform-version}</ignition-sdk-version>
         <module-name>OPC UA Device Example</module-name>
         <module-description>Shows how to implement a new OPC UA device type</module-description>


### PR DESCRIPTION
Milo was upgraded to 0.4.x in this version, which made SubscriptionModel a Lifecycle that needs to be started and stopped.