### PR TITLE
remove deactivated teamdev maven repo

### DIFF
--- a/perspective-component/build.gradle
+++ b/perspective-component/build.gradle
@@ -82,18 +82,10 @@ allprojects {
     // where should we try to resolve maven artifacts from?
     repositories {
         mavenLocal()
-        mavenCentral()
-        google()
-        jcenter()
-
-        maven {
-            name "teamdev"
-            url "http://maven.teamdev.com/repository/products"
-
-        }
         maven { url "https://nexus.inductiveautomation.com/repository/inductiveautomation-releases/" }
         maven { url "https://nexus.inductiveautomation.com/repository/inductiveautomation-thirdparty/" }
         maven { url "https://nexus.inductiveautomation.com/repository/inductiveautomation-snapshots/" }
+        mavenCentral()
     }
 }
 


### PR DESCRIPTION
This should Fix #59 

Teamdev changed to a different artifact repo host (google cloud) which changed the URL.  Rather than replace with the new URL, we've added a proxy/mirror as part of the inductiveautomation-thirdparty repository sources.  With this change, explicitly specifying the teamdev repo should no longer be necessary. 

In addition, I'm also removing _jcenter_, which is slated for [shutdown](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/), and the google repo, as it's redundant.


