### PR TITLE
Adding a Standards section under the SDK Tips header for Perspective Components

### DIFF
--- a/perspective-component/README.md
+++ b/perspective-component/README.md
@@ -182,4 +182,8 @@ the various tools used and linked above to determine the appropriate build confi
 
 Perspective is a fairly complex system that is seeing regular changes/additions.  While we consider the APIs 'mostly stable', there will likely be additions and/or breaking changes as it matures.  As a result, we encourage testing modules against each version of Ignition/Perspective you intend to support.
 
+#### Standards
+
+As of the 8.1.14 release, a `ref` is passed down to the component via `emit` (emit props).  This is required to provide back a reference to the root element of each component, which is used internally by the Perspective module.  For this reason, the root element of any authored components cannot contain a `ref` property.  Doing so will override the emitted ref and will not allow your component to properly display any changes to the state of its qualities and may cause the component to throw an error. 
+
 

--- a/perspective-component/README.md
+++ b/perspective-component/README.md
@@ -184,6 +184,13 @@ Perspective is a fairly complex system that is seeing regular changes/additions.
 
 #### Standards
 
-As of the 8.1.14 release, a `ref` is passed down to the component via `emit` (emit props).  This is required to provide back a reference to the root element of each component, which is used internally by the Perspective module.  For this reason, the root element of any authored components cannot contain a `ref` property.  Doing so will override the emitted ref and will not allow your component to properly display any changes to the state of its qualities and may cause the component to throw an error. 
+As of the 8.1.4 release, a `ref` is passed down to the component via `emit` (emit props).  This is required to 
+provide back a reference to the root element of each component, which is used internally by the Perspective module.  
+For this reason, the root element of any authored components cannot contain a `ref` property.  Doing so will 
+override the emitted ref and will not allow your component to properly display any changes to the state of its 
+qualities and may cause the component to throw an error.  The ref can still be accessed from the component's store, 
+if needed.  In addition, it is highly recommended that the root element does not change throughout the lifecycle 
+of the component.  For more information and an example usage, see the `MessengerComponent` from the example
+components.
 
 

--- a/perspective-component/web/README.md
+++ b/perspective-component/web/README.md
@@ -6,7 +6,7 @@ about the tools/requirements used to build the final JS that can be used for per
 ## Requirements ##
 
 There are two different ways to build these component resources.  The easiest is to simply allow Gradle to handle the build by 
-running `./gradlew :web:build` (macOs/linux) or `gradle.bat :web:build` (windows) from the root of the project.  Doing this will 
+running `./gradlew :web:build` (macOs/linux) or `gradlew.bat :web:build` (windows) from the root of the project.  Doing this will 
 download Node, Npm, Yarn, with versions set to those specified in the `web/build.gradle` configuration file.
 
 It will then execute the typescript compilation using these downloaded binaries.

--- a/perspective-component/web/packages/client/typescript/components/Image.tsx
+++ b/perspective-component/web/packages/client/typescript/components/Image.tsx
@@ -29,8 +29,9 @@ export class Image extends Component<ComponentProps<ImageProps>, any> {
         const { props: { url }, emit } = this.props;
         // Read the 'url' property provided by the perspective gateway via the component 'props'.
 
-        // Note that the topmost piece of dom requires the application of events, style and className as shown below
-        // otherwise the layout won't work, or any events configured will fail. See render of MessengerComponent in Messenger.tsx
+        // Note that the topmost piece of dom requires the application of an element reference, events, style and
+        // className as shown below otherwise the layout won't work, or any events configured will fail. See render
+        // of MessengerComponent in Messenger.tsx for more details.
         return (
             <img
                 {...emit()}

--- a/perspective-component/web/packages/client/typescript/components/Messenger.tsx
+++ b/perspective-component/web/packages/client/typescript/components/Messenger.tsx
@@ -188,6 +188,15 @@ export class MessageComponentGatewayDelegate extends ComponentStoreDelegate {
  * a registered ComponentDelegate as it does in this example.
  */
 export class MessengerComponent extends Component<ComponentProps<MessagePropConfig, MessengerDelegateState>, {}> {
+
+    rootElementRef: Element | void;
+
+    componentDidMount() {
+        // If a reference to the root element is needed, it can be achieved using `this.props.store.element` after the
+        // component has mounted.
+        this.rootElementRef = this.props.store.element;
+    }
+
     @bind
     fireUpdateToGateway(): void {
         // We know a delegate exists because we've set implemented `createDelegate` in 
@@ -221,11 +230,15 @@ export class MessengerComponent extends Component<ComponentProps<MessagePropConf
         const buttonText: string = this.props.delegate!.messagePending ? "Waiting" : "Send Message";
         return (
             // Note that the topmost piece of DOM requires the use of the 'emitter' provided by props in order for
-            // containers to appropriately position them in addition to attaching event listeners and styles.  
+            // containers to appropriately position them in addition to attaching an element reference, event listeners, and styles.
             // Adding your own events here or styles here outside of the emitter will cause an override depending on 
             // the order in which they are declared relative to the invocation of the emitter. Add inline styles and classes
             // as shown below.  Add event listeners by using `this.props.domEvents.addListener` in the constructor or on mount,
-            // and be sure to remove these listeners to prevent memory leaks on un-mount.  
+            // and be sure to remove these listeners to prevent memory leaks on un-mount.  If a reference to the root element
+            // is needed, this can be done by using `this.props.store.element` as opposed to declaring a `ref` on the
+            // root element.  The later will override the emitted ref and will not allow your component to properly
+            // display any changes to the state of its qualities and may cause the component to throw an error.  It is
+            // also highly recommended that the root element does not change throughout the lifecycle of the component.
             <div {...this.props.emit({ classes: ["messenger-component"] })}>
                 <h3 className="counter">
                     {this.props.delegate!.messageCount}

--- a/perspective-component/web/packages/client/typescript/components/TagCounter.tsx
+++ b/perspective-component/web/packages/client/typescript/components/TagCounter.tsx
@@ -85,9 +85,9 @@ export class TagCounter extends Component<ComponentProps<TagCountProps>, TagCoun
 
         const counterClasses = this.state.animating ? 'tag-counter-count message-animation' : 'tag-counter-count';
 
-        // Note that the topmost piece of dom requires the application of events, style and className as shown below
-        // otherwise the layout won't work, or any events configured will fail. See render of MessengerComponent in 
-        // Messenger.tsx for more details.
+        // Note that the topmost piece of dom requires the application of an element reference, events, style and
+        // className as shown below otherwise the layout won't work, or any events configured will fail. See render
+        // of MessengerComponent in Messenger.tsx for more details.
         return (
             <div {...emit({ classes: ['tag-counter-component'] })}>
                 <span className={counterClasses}>{this.state.tagCount}</span>


### PR DESCRIPTION
This explains the addition of the `ref` property in the `emit` properties that are emitted to components and cautions the component author against using a `ref` property pn the root element of their component.