### PR TITLE
Use MESSAGE_REQUEST_EVENT over MESSAGE_RESPONSE_EVENT in fireGatewayM…

### DIFF
--- a/perspective-component/web/packages/client/typescript/components/Messenger.tsx
+++ b/perspective-component/web/packages/client/typescript/components/Messenger.tsx
@@ -130,7 +130,7 @@ export class MessageComponentGatewayDelegate extends ComponentStoreDelegate {
 
     // Used by our component to fire a message to the gateway.
     public fireGatewayMessage(): void {
-        this.fireDelegateEvent(MessageEvents.MESSAGE_RESPONSE_EVENT, { count: this.messageCount });
+        this.fireDelegateEvent(MessageEvents.MESSAGE_REQUEST_EVENT, { count: this.messageCount });
     }
 
     /**


### PR DESCRIPTION
…essage in Messenger Component client code

When loading this module, the perspective Messenger component does not complete a full round trip. I found that the client-side script is using the wrong event name, so the gateway code is ignoring the message entirely and not sending a response.