### PR TITLE
Updating the gradlew reference

### DIFF
--- a/perspective-component/README.md
+++ b/perspective-component/README.md
@@ -64,7 +64,7 @@ To run the build, clone this repo and open a command line in the `perspective-co
 gradlew.bat buildModule
 
 // on linux/osx
-./gradlew.sh buildModule
+sh ./gradlew buildModule
 ```
 
 If you would like to be able to execute parts of the build without depending on gradle, you'll need familiarity with


### PR DESCRIPTION
In the getting started it calls the `gradlew` file as having the `.sh` file extension, but it doesn't! So it should be executed with`sh`

This is in reference to issue #82 