### PR TITLE
fix web dependency configuration, perspective module config, add integration notes to web readme

### DIFF
--- a/perspective-component/README.md
+++ b/perspective-component/README.md
@@ -123,15 +123,15 @@ Within the `web` directory is a _lerna workspace_, which is simply a javascript 
 
   ├── build.gradle.kts                     // root build configuration, like a root pom.xml file
   ├── common
-  │   ├── build.gradle                     // configuration for common scoped build
+  │   ├── build.gradle.kts                     // configuration for common scoped build
   │   └── src
   │       └── main/java                    // where source files live
   ├── designer
-  │   ├── build.gradle
+  │   ├── build.gradle.kts
   │   └── src
   │       └── main/java
   ├── gateway
-  │   ├── build.gradle
+  │   ├── build.gradle.kts
   │   └── src
   │       └── main/java
   ├── gradle                              // gradle wrapper assets to allow wrapper functionality,should be commited
@@ -143,7 +143,6 @@ Within the `web` directory is a _lerna workspace_, which is simply a javascript 
   ├── settings.gradle.kts                 // Gradle project structure/global configuration.
   └── web                                 // parent directory for the web assets we build
       ├── README.md
-      ├── build.gradle
       ├── build.gradle.kts
       ├── lerna.json                      // lerna configuration file
       │

--- a/perspective-component/README.md
+++ b/perspective-component/README.md
@@ -117,6 +117,7 @@ Within the `web` directory is a _lerna workspace_, which is simply a javascript 
   registries.
 
 
+
 ```
 
 
@@ -143,6 +144,7 @@ Within the `web` directory is a _lerna workspace_, which is simply a javascript 
   └── web                                 // parent directory for the web assets we build
       ├── README.md
       ├── build.gradle
+      ├── build.gradle.kts
       ├── lerna.json                      // lerna configuration file
       │
       ├── package.json

--- a/perspective-component/build.gradle.kts
+++ b/perspective-component/build.gradle.kts
@@ -28,12 +28,7 @@ ignitionModule {
     // If we depend on other module being loaded/available, then we specify IDs of the module we depend on,
     // and specify the Ignition Scope that applies. "G" for gateway, "D" for designer, "C" for VISION client
     // (this module does not run in the scope of a Vision client, so we don't need a "C" entry here)
-    moduleDependencies.putAll(
-        mapOf(
-            "com.inductiveautomation.perspective" to "G",
-            "com.inductiveautomation.perspective" to "D"
-        )
-    )
+    moduleDependencies.put("com.inductiveautomation.perspective", "DG")
 
     // map of 'Gradle Project Path' to Ignition Scope in which the project is relevant.  This is is combined with
     // the dependency declarations within the subproject's build.gradle.kts in order to determine which

--- a/perspective-component/gateway/build.gradle.kts
+++ b/perspective-component/gateway/build.gradle.kts
@@ -14,7 +14,7 @@ dependencies {
     // as 'api(project(":common"))'. See https://docs.gradle.org/7.0/release-notes.html on Type-safe project accessors
     implementation(projects.common)
 
-    implementation(projects.web)
+    modlImplementation(projects.web)
 
     // declare our dependencies on ignition sdk elements.  These are defined in the gradle/libs.versions.toml file of
     // the root project for this module

--- a/perspective-component/web/README.md
+++ b/perspective-component/web/README.md
@@ -4,39 +4,54 @@ This folder contains all the Typescript source files for the custom component se
 about the tools/requirements used to build the final JS that can be used for perspective.  It's important to note that
 there are many options for assembling frontend (javascript, css) files.  These are just examples, and it's up to the
 developer to learn them, or choose your own alternatives.  The important part is that you generate js that is consistent
-with the APIs provided by the browser-side perspective runtime, and that this js is available to the gateway at 
+with the APIs provided by the browser-side perspective runtime, and that this js is available to the gateway at
 runtime, which is accomplished through the component registry and descriptors demonstrated in the gateway and common
-projects.  
+projects.
 
 ## Requirements ##
 
-There are two different ways to build these component resources.  The easiest is to simply allow Gradle to handle the build by 
-running `./gradlew :web:build` (macOs/linux) or `gradlew.bat :web:build` (windows) from the root of the project.  Doing this will 
+There are two different ways to build these component resources.  The easiest is to simply allow Gradle to handle the build by
+running `./gradlew :web:build` (macOs/linux) or `gradlew.bat :web:build` (windows) from the root of the project.  Doing this will
 download Node, Npm, Yarn, with versions set to those specified in the `web/build.gradle` configuration file.
 
 It will then execute the typescript compilation using these downloaded binaries.
 
-Alternatively, the packages can be built at the commandline, but require locally (user) installed versions of the 
+Alternatively, the packages can be built at the commandline, but require locally (user) installed versions of the
 following dependencies:
 
 * Node JS
 * Npm (the Node Package Manager)
-* Typescript 
-* Webpack 
+* Typescript
+* Webpack
 * Lerna
 * Yarn
 
-Versions of these dependencies are defined in the `package.json` files found in the web/ directory, generally as  _devDependencies_ section.  The root package.json defines shared dev dependency configurations used by the subprojects in 'web/packages/'  
+Versions of these dependencies are defined in the `package.json` files found in the web/ directory, generally as  _devDependencies_ section.  The root package.json defines shared dev dependency configurations used by the subprojects in 'web/packages/'
 
-The suggested install route for these is to install the latest LTS version of NPM (which will also install Node) as per 
+The suggested install route for these is to install the latest LTS version of NPM (which will also install Node) as per
 the typical npm install route, and then use npm itself to install the other dependencies.
 
-With NPM installed, the following command will install the remaining dependents (should not require sudo/admin privs to 
+With NPM installed, the following command will install the remaining dependents (should not require sudo/admin privs to
 succeed):
 
 `npm i -g typescript tslint webpack lerna`
 
 Building using these locally installed tools is described below in the 'Usage' section.
+
+## How the Web Package are Included in the Module ##
+
+The web files we create (js/css/etc) need to be resolvable as _resources_ by the Java Classloader.
+Prior to updating the module plugin to the new open-source version (`io.ia.sdk.modl`), we used a simple copy mechanism
+to get our js and css files into the _gateway_ scoped classpath.  In doing so, we simply copied the files into the
+gateway folder's _src/main/resources/mounted/_ folder.  This is a functional solution, but is not a great practice for
+a number of reasons: the risk of ending up with multiple/stale copies in your resource folder, the need to .gitignore,
+and the inability to properly support Gradle's [incremental assembly](https://docs.gradle.org/current/userguide/more_about_tasks.html#sec:up_to_date_checks)
+(the gateway jar needs to get rebuilt if our web assets change, because its resources have changed), and more.
+
+In this current project, the _web_ project itself is built into a jar file (artifact) whose contents are simply the web
+resources. This _web_ artifact is a dependency of the _gateway_ subproject, which gives the gateway classloader the
+same ability to resolve the resources (js/css files), without needing to mutate the gateway jar at all.
+
 
 ### About These Dependencies ###
 
@@ -44,36 +59,36 @@ Briefly - these tools serve the following purposes:
 
 * *Lerna* - used to orchestrate the building of multiple inter-dependent node packages
 * *Yarn* - used as a dependency manager, replacing `npm` as the package manager in the context of the `web/` packages being
-built. 
+built.
 * *Webpack* - a 'bundler', which is ultimately a build tool that combines or _bundles_ the necessary files/source into something
-that may be used as a `<script>` file on a web page.  Through plugins/configuration, it can strip excess/unused/unreachable 
+that may be used as a `<script>` file on a web page.  Through plugins/configuration, it can strip excess/unused/unreachable
 code, minify, uglify, create source maps for browser-enabled debugging, etc.  The configuration provided in this example
 is a bare-minimum 'simple use' case which includes the use of the _Typescript Loader_ to manager the typescript
 compilation prior to bundling.
 * *Typescript* - A superset of Javascript, which allows for strong typing, fuller OOP support.  Ultimately compiles
- (sometimes called _transpiles_ ) to javascript.  Javascript version compatibility depends on configuration of 
+ (sometimes called _transpiles_ ) to javascript.  Javascript version compatibility depends on configuration of
  `tsconfig.json`, and webpack.
 
 
 ## Directory Structure Information ##
 
-Perspective has different 'scopes', much like Vision.  The 'client' scope refers to a perspective project running in a 
+Perspective has different 'scopes', much like Vision.  The 'client' scope refers to a perspective project running in a
 web browser.  The 'designer' scope refers to a perspective project executing in the Ignition Designer's Perspective View
-Workspace (perspective resource editor).  Similar to the OOP principles used in Vision, perspective's designer scope 
-builds on top of the client scope, adding designer-specific functionality.  
+Workspace (perspective resource editor).  Similar to the OOP principles used in Vision, perspective's designer scope
+builds on top of the client scope, adding designer-specific functionality.
 
-These scopes are distinct in that the designer may have UI/runtime elements that are not present in the client, such as design-specific layout guides/ui,'rulers', and 'interaction delegates' implemented by advanced components and containers in order to provide additional functionality in the designer.  
+These scopes are distinct in that the designer may have UI/runtime elements that are not present in the client, such as design-specific layout guides/ui,'rulers', and 'interaction delegates' implemented by advanced components and containers in order to provide additional functionality in the designer.
 
-As a result, we have two different folders under the 'packages' directory - one for client which is loaded when a 
-project loads and executes once published.  The other for the designer, which depends on and may extend the client 
-scoped components, and exists only within the designer.  
+As a result, we have two different folders under the 'packages' directory - one for client which is loaded when a
+project loads and executes once published.  The other for the designer, which depends on and may extend the client
+scoped components, and exists only within the designer.
 
 Using Lerna and Yarn allows us to resolve these dependencies locally, and allows for a more sane development experience.
 
 Each subpackage withing `packages` has a number of files.  Here is a brief description of the file and what it does:
 
-* *.npmrc* - Contains configuration used by npm (as well as in our case - yarn), to determine where it resolves 
-packages.  Notably, this is required to tell our dependency manager that dependencies containing the 
+* *.npmrc* - Contains configuration used by npm (as well as in our case - yarn), to determine where it resolves
+packages.  Notably, this is required to tell our dependency manager that dependencies containing the
 `@inductiveautomation` scope prefix should resolve against the Inductive Automation node package repository, similar to
  how we provide maven artifacts.
  * *webpack.config.js* - configuration file used for webpack, bearing the default webpack name.
@@ -81,32 +96,32 @@ packages.  Notably, this is required to tell our dependency manager that depende
  optionally contain configuration for additional tools.
  * *tsconfig.json* - Contains configuration specific to the typescript compiler as well as (optionally) configuration
  for typescript related build plugins/tools
- * *yarn.lock* - a dependency 'lock file' - which is used to 'lock' the dependency structure into specific versions and 
- a statically-defined dependency graph.  By default, npm packages don't have this consistency.  This file should be 
+ * *yarn.lock* - a dependency 'lock file' - which is used to 'lock' the dependency structure into specific versions and
+ a statically-defined dependency graph.  By default, npm packages don't have this consistency.  This file should be
  committed and saved any time a dependency is changed/added.
- * *typescript/* - folder containing all the typescript source files.  The root `<scopename>.ts` is the 'index' or 
- 'entry' point of the package.  All components intended to be usable at runtime must be exported from this root index, 
+ * *typescript/* - folder containing all the typescript source files.  The root `<scopename>.ts` is the 'index' or
+ 'entry' point of the package.  All components intended to be usable at runtime must be exported from this root index,
  otherwise it may get 'pruned' from the final javascript file.
- * *dist/* - the `distribution` or `build output` directory.  It's created and populated with the result of your 
- typescript --> webpack bundling.  May be safely deleted, will be recreated on next build. 
+ * *dist/* - the `distribution` or `build output` directory.  It's created and populated with the result of your
+ typescript --> webpack bundling.  May be safely deleted, will be recreated on next build.
 
 ## Usage ##
 
 If not using the gradle build (which is likely overkill if only seeking to rebuild the typescript packages), you can use
 the following procedure to install dependencies and compile the files.
 
-1. Execute `yarn` through the commandline in the `./web/` directory.  This will download and install node dependencies, 
+1. Execute `yarn` through the commandline in the `./web/` directory.  This will download and install node dependencies,
 described in the package.jsons of all packages, including the perspective-client and perspective-designer dependencies.
-This command only needs to be run one time initially, and then once follow any changes to dependencies in package.json, 
+This command only needs to be run one time initially, and then once follow any changes to dependencies in package.json,
 or if node_modules folders (the local dependency cache folder) are deleted.  It only needs to be run once, in the root
 of the `web` folder, and will establish the dependencies for child packages.
 
 2. Execute `lerna run build` - which will execute the build scripts for each child package.
 
-## Notes ## 
+## Notes ##
 
 * Typescript, webpack, etc, is not required to build a module with components for Perspective. We recommend it as best
-practice, but you are free to create your javascript any way you would prefer. 
+practice, but you are free to create your javascript any way you would prefer.
 * dist/ contains the final output of a build
 * The webpack build finalizes with the copying of the webpacked resources from each packages `dist/` folder into the
 gateway scoped `resources/mounted/js/` folder, which is where perspective will look to retrieve them.  This location is

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,14 @@
 # Ignition SDK
 
 ## Example Modules
+
+### Gradle Examples
+
+##### [Perspective Component](perspective-component)
+Adds a simple image component to the Perspective module's set of components.  In addition, utilizes Gradle as the build tool.  See the example readme for additional information.
+
+### Maven Examples
+
 ##### [Expression Function](expression-function)
 Creates an exampleMultiply expression that can be used by other components, such as expression tags. The example expression is located under the Extended expression category.
 
@@ -8,16 +16,13 @@ Creates an exampleMultiply expression that can be used by other components, such
 Requires two Gateways connected via the gateway network. The module must also be installed on both Gateways. This module adds a system.example.getRemoteLogEntries script function that can retrieve console log entries from a remote Gateway over the gateway network. Also adds a Gateway Task type that can retrieve a remote gateway’s wrapper log and save as a local file.
 
 ##### [Gateway Webpage/Home Connect](gateway-webpage)
-Demonstrates how to implement Gateway Status and Config pages. HomeConnect pages are added to the Gateway that configure an imaginary HomeConnect device. 
+Demonstrates how to implement Gateway Status and Config pages. HomeConnect pages are added to the Gateway that configure an imaginary HomeConnect device.
 
 ##### [Managed Tag Provider](managed-tag-provider)
 Shows how to implement a Managed Tag Provider, to allow easy control of Ignition tags from an external program or data.
 
 ##### [OPC UA Device](opc-ua-device)
 Creates an example device in the Gateway. The device will create tags that are visible under the local OPC-UA server.
-
-##### [Perspective Component](perspective-component)
-Adds a simple image component to the Perspective module's set of components.  In addition, utilizes Gradle as the build tool.  See the example readme for additional information.
 
 ##### [Report Component](report-component)
 Adds a Smiley shaped component to the Report Designer.
@@ -34,26 +39,42 @@ Adds a Slack Alarm Notification type that handles alarm notifications through Sl
 ##### [Vision Component](vision-component)
 Creates a Hello World component that can be dragged onto a window in the Designer.
 
-## Requirements
-* Java Development Kit (JDK) 11 installed. You can download it on the [Java SDK Downloads](http://www.oracle.com/technetwork/java/javase/downloads/index-jsp-138363.html) page.
-* Maven 3.+ installed. Linux users can use their package manager to install at the command line (ex: `sudo apt-get install maven`), and similarly OSX users using brew can `brew install maven`. Windows users can install via [Chocolatey](https://chocolatey.org/) (`choco install maven`) or by downloading the installer at the [Maven downloads](http://maven.apache.org/download.cgi_) page.
-* A running, 8.0+ version of Ignition to test your module in. If you don't already have Ignition installed head to the Inductive Automation [downloads](https://www.inductiveautomation.com/downloads/) page, download the correct package for your system and follow the installation instructions to get a gateway up and running.  
-* For development, you will want to allow unsigned modules. Open the `ignition.conf` file in the `data/` directory, then in the `wrapper.java.additional` section add a line like: `wrapper.java.additional.7=-Dignition.allowunsignedmodules=true` (the index does not matter).
+## The Module Build System
+
+These examples utilize either Maven and our Maven Plugin, or Gradle and our [Gradle Plugin](https://github.com/inductiveautomation/ignition-module-tools).  Both tools are mature and capable, offering different tradeoffs in terms of performance, ease of customization, language support, etc.  If you prefer XML configuration, take a look at Maven.  If you prefer declarative programming-language based configuration, check out Gradle.  Inductive Automation uses Gradle to build Ignition and our own modules with the same open source plugin linked above.
+
+The ignition-maven-plugin is available through our [Nexus Repository](https://nexus.inductiveautomation.com/repository/inductiveautomation-releases/) (see examples for how to add to dependency sources).
+
+The Gradle Plugin is published to the [Gradle Plugin Portal](https://plugins.gradle.org/plugin/io.ia.sdk.modl), and may be used simply by applying the plugin to your gradle project.
+
+
+## General Requirements
+
+These requirements generally apply to both Gradle and Maven build tools.
+
+* Java Development Kit (JDK) 11 installed. You can download it on the [Java SDK Downloads](http://www.oracle.com/technetwork/java/javase/downloads/index-jsp-138363.html) page.  Licensed/TCK tested JDK vendors such as Adoptium, Azul Zulu, etc, are generally suitable JDKs as well.
+* A running, 8.0+ version of Ignition to test your module in. If you don't already have Ignition installed head to the Inductive Automation [downloads](https://www.inductiveautomation.com/downloads/) page, download the correct package for your system and follow the installation instructions to get a gateway up and running.
+* For development convenience, you may want to allow unsigned modules. Open the `ignition.conf` file in the `data/` directory, then in the `wrapper.java.additional` section add a line like: `wrapper.java.additional.7=-Dignition.allowunsignedmodules=true` (the index does not matter).
 
 ## Getting Started
+
 * Once you have configured your developer gateway, make sure [git](https://git-scm.com/downloads) is installed and clone this repo to a directory of your choice:
     `git clone https://github.com/inductiveautomation/ignition-sdk-examples.git`
 
-* Using your IDE of choice, you should be able to create or open any of these included Example Modules through the parent pom.xml file located in the root of each example.  Upon importing this project into your IDE, it should download (if auto-import is on) Maven dependencies from the Inductive Automation artifact repository. Dependencies are managed through Maven and are cached to your local environment after they are downloaded.
+* Using your IDE of choice, you should be able to create or open any of these included Example Modules through the _pom.xml_ or _settings.gradle.kts_, file located in the root of each example.  Upon importing this project into your IDE, it should download (if auto-import is on) necessary dependencies from the Inductive Automation artifact repository. Dependencies are managed through Maven and are cached to your local environment after they are downloaded.
+
+## Running Maven Examples
+
+* First, make sure Maven 3.+ installed. Linux users can use their package manager to install at the command line (ex: `sudo apt-get install maven`), and similarly OSX users using brew can `brew install maven`. Windows users can install via [Chocolatey](https://chocolatey.org/) (`choco install maven`) or by downloading the installer at the [Maven downloads](http://maven.apache.org/download.cgi_) page.
 
 * Once all dependencies are cached, you should be able to run `mvn package` in any of the examples to generate the *.modl* file (which will be created in the `build\target\` directory of the example).  The modl file is the Ignition module file you install to the Dev Mode Ignition in `Config > Modules` in your browser's Gateway page (generally found at `http://localhost:8088/main`). Alternately, if on a Unix system, you can use the `buildall.sh` file in the base directory to build all modules.
 
 * Then, from the Ignition gateway web interface, head to Configure -> Modules, and scroll down to install any of your built modules from the `/module/module-build/` directory.
 
-## The Module Build System
-These examples utilize Maven and our Maven Plugin.  The ignition-maven-plugin is available through our [Nexus Repository](https://nexus.inductiveautomation.com/repository/inductiveautomation-releases/) (see examples for how to add to depenency sources).  
+## Running Gradle Examples
 
-The pom files in these examples should prove useful tools to understanding how the new SDK works while we update the documentation in preparation for the full release of this new SDK.  
+For instructions on how to build with the Gradle plugin, take a look at the documentation on the [Gradle Plugin](https://github.com/inductiveautomation/ignition-module-tools/tree/master/gradle-module-plugin) repository.
+
 
 ## Javadocs
-Head over to our [wiki page](https://github.com/inductiveautomation/ignition-sdk-examples/wiki/Javadocs-&-Notable-Api-Changes) for a listing of 8.0+ javadocs. 
+Head over to our [wiki page](https://github.com/inductiveautomation/ignition-sdk-examples/wiki/Javadocs-&-Notable-Api-Changes) for a listing of 8.0+ javadocs.


### PR DESCRIPTION
Fixes #93 

Two different issues identified:

1. The primary issue when loading the module was due to improperly set perspective module dependency configuration.  

2. The web project did seem to build correctly for me, but was not properly getting included into the assembled module

In addition, I added some documentation to explain the change in how the web assets are integrated into the project.

Contrary to the original changes, I checked this fix in completely clean checkout and it successfully loaded into an 8.1.22 gateway. 