### PR TITLE
Update sdk-examples to Java 17 and Resolved the internal error on the gateway-network-function module

### DIFF
--- a/expression-function/expression-function-build/pom.xml
+++ b/expression-function/expression-function-build/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>expression-function</artifactId>
         <groupId>com.inductiveautomation.ignition.examples</groupId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>expression-function-build</artifactId>

--- a/expression-function/expression-function-client/pom.xml
+++ b/expression-function/expression-function-client/pom.xml
@@ -65,10 +65,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.2</version>
+                <version>3.8.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/expression-function/expression-function-client/pom.xml
+++ b/expression-function/expression-function-client/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>expression-function</artifactId>
         <groupId>com.inductiveautomation.ignition.examples</groupId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>expression-function-client</artifactId>

--- a/expression-function/expression-function-common/pom.xml
+++ b/expression-function/expression-function-common/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>expression-function</artifactId>
         <groupId>com.inductiveautomation.ignition.examples</groupId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>expression-function-common</artifactId>

--- a/expression-function/expression-function-common/pom.xml
+++ b/expression-function/expression-function-common/pom.xml
@@ -27,10 +27,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.2</version>
+                <version>3.8.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/expression-function/expression-function-designer/pom.xml
+++ b/expression-function/expression-function-designer/pom.xml
@@ -63,10 +63,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.2</version>
+                <version>3.8.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/expression-function/expression-function-designer/pom.xml
+++ b/expression-function/expression-function-designer/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>expression-function</artifactId>
         <groupId>com.inductiveautomation.ignition.examples</groupId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>expression-function-designer</artifactId>

--- a/expression-function/expression-function-gateway/pom.xml
+++ b/expression-function/expression-function-gateway/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>expression-function</artifactId>
         <groupId>com.inductiveautomation.ignition.examples</groupId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>expression-function-gateway</artifactId>

--- a/expression-function/expression-function-gateway/pom.xml
+++ b/expression-function/expression-function-gateway/pom.xml
@@ -41,10 +41,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.2</version>
+                <version>3.8.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/expression-function/pom.xml
+++ b/expression-function/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.inductiveautomation.ignition.examples</groupId>
     <artifactId>expression-function</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/gateway-network-function/gateway-network-function-build/pom.xml
+++ b/gateway-network-function/gateway-network-function-build/pom.xml
@@ -71,7 +71,7 @@
                         </projectScope>
                     </projectScopes>
 
-                    <moduleId>com.inductiveautomation.ignition.examples.gan-function</moduleId>
+                    <moduleId>com.inductiveautomation.examples.gateway-network-function</moduleId>
                     <moduleName>${module-name}</moduleName>
                     <moduleDescription>${module-description}</moduleDescription>
                     <moduleVersion>${project.version}</moduleVersion>

--- a/gateway-network-function/gateway-network-function-build/pom.xml
+++ b/gateway-network-function/gateway-network-function-build/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>gateway-network-function</artifactId>
         <groupId>com.inductiveautomation.examples</groupId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-network-function-build</artifactId>

--- a/gateway-network-function/gateway-network-function-client/pom.xml
+++ b/gateway-network-function/gateway-network-function-client/pom.xml
@@ -67,8 +67,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.2</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/gateway-network-function/gateway-network-function-client/pom.xml
+++ b/gateway-network-function/gateway-network-function-client/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>gateway-network-function</artifactId>
         <groupId>com.inductiveautomation.examples</groupId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-network-function-client</artifactId>

--- a/gateway-network-function/gateway-network-function-common/pom.xml
+++ b/gateway-network-function/gateway-network-function-common/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>gateway-network-function</artifactId>
         <groupId>com.inductiveautomation.examples</groupId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-network-function-common</artifactId>

--- a/gateway-network-function/gateway-network-function-common/pom.xml
+++ b/gateway-network-function/gateway-network-function-common/pom.xml
@@ -29,8 +29,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.2</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/gateway-network-function/gateway-network-function-designer/pom.xml
+++ b/gateway-network-function/gateway-network-function-designer/pom.xml
@@ -64,8 +64,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.2</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/gateway-network-function/gateway-network-function-designer/pom.xml
+++ b/gateway-network-function/gateway-network-function-designer/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>gateway-network-function</artifactId>
         <groupId>com.inductiveautomation.examples</groupId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-network-function-designer</artifactId>

--- a/gateway-network-function/gateway-network-function-gateway/pom.xml
+++ b/gateway-network-function/gateway-network-function-gateway/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>gateway-network-function</artifactId>
         <groupId>com.inductiveautomation.examples</groupId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-network-function-gateway</artifactId>

--- a/gateway-network-function/gateway-network-function-gateway/pom.xml
+++ b/gateway-network-function/gateway-network-function-gateway/pom.xml
@@ -43,8 +43,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.2</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/gateway-network-function/gateway-network-function-gateway/src/main/java/com/inductiveautomation/ignition/examples/GatewayHook.java
+++ b/gateway-network-function/gateway-network-function-gateway/src/main/java/com/inductiveautomation/ignition/examples/GatewayHook.java
@@ -44,7 +44,7 @@ public class GatewayHook extends AbstractGatewayModuleHook {
         sm.registerService(GetLogsService.class, getLogsService);
 
         // Task setup
-        registeredTasks.add(new GetWrapperLogTaskType());
+        registeredTasks.add(new GetWrapperLogTaskType(context));
         for(TaskType tt: registeredTasks){
             context.getTaskManager().registerTaskType(tt);
         }

--- a/gateway-network-function/gateway-network-function-gateway/src/main/java/com/inductiveautomation/ignition/examples/GatewayHook.java
+++ b/gateway-network-function/gateway-network-function-gateway/src/main/java/com/inductiveautomation/ignition/examples/GatewayHook.java
@@ -44,7 +44,7 @@ public class GatewayHook extends AbstractGatewayModuleHook {
         sm.registerService(GetLogsService.class, getLogsService);
 
         // Task setup
-        registeredTasks.add(new GetWrapperLogTaskType(context));
+        registeredTasks.add(new GetWrapperLogTaskType());
         for(TaskType tt: registeredTasks){
             context.getTaskManager().registerTaskType(tt);
         }

--- a/gateway-network-function/gateway-network-function-gateway/src/main/java/com/inductiveautomation/ignition/examples/service/GetLogsServiceImpl.java
+++ b/gateway-network-function/gateway-network-function-gateway/src/main/java/com/inductiveautomation/ignition/examples/service/GetLogsServiceImpl.java
@@ -75,10 +75,10 @@ public class GetLogsServiceImpl implements GetLogsService, SecuredEntityImplemen
 
 
         // If all security checks passed, we can continue. Start by making a temporary copy of wrapper.log
-        File wrapperFile = new File(context.getSystemManager().getLogsDir() + File.separator + "wrapper.log");
+        File wrapperFile = new File(context.getSystemManager().getLogsDir() + File.separator + "system_logs.idb");
         File tempLog;
         if(wrapperFile.exists()){
-            tempLog = new File(System.getProperty("java.io.tmpdir") + File.separator + UUID.randomUUID().toString() + ".wrapper.log");
+            tempLog = new File(System.getProperty("java.io.tmpdir") + File.separator + UUID.randomUUID().toString() + ".system_logs.idb");
             try {
                 FileUtils.copyFile(wrapperFile, tempLog);
             } catch (IOException e) {
@@ -89,7 +89,7 @@ public class GetLogsServiceImpl implements GetLogsService, SecuredEntityImplemen
         }
         else{
             logger.warn(String.format("%s does not exist. Log file will not be sent", wrapperFile.getAbsolutePath()));
-            return GetLogsService.FAIL_MSG + ": wrapper.log file was not found";
+            return GetLogsService.FAIL_MSG + ": system_logs.idb file was not found";
         }
 
         String finalResult;
@@ -116,7 +116,7 @@ public class GetLogsServiceImpl implements GetLogsService, SecuredEntityImplemen
         // The passed wrapperFilePath holds the path to the streamed wrapper.log file on the local system.
         // From here, you can move the file to an archived location as you see fit. You will need to return
         // a success or fail message so the original caller can report on the task execution.
-        logger.info(String.format("Streamed wrapper.log file for server '%s' is available here: %s",
+        logger.info(String.format("Streamed system_logs.idb file for server '%s' is available here: %s",
                 sourceServerId.toDescriptiveString(),
                 wrapperFilePath));
 

--- a/gateway-network-function/gateway-network-function-gateway/src/main/java/com/inductiveautomation/ignition/examples/service/GetLogsServiceImpl.java
+++ b/gateway-network-function/gateway-network-function-gateway/src/main/java/com/inductiveautomation/ignition/examples/service/GetLogsServiceImpl.java
@@ -75,10 +75,10 @@ public class GetLogsServiceImpl implements GetLogsService, SecuredEntityImplemen
 
 
         // If all security checks passed, we can continue. Start by making a temporary copy of wrapper.log
-        File wrapperFile = new File(context.getSystemManager().getLogsDir() + File.separator + "system_logs.idb");
+        File wrapperFile = new File(context.getSystemManager().getLogsDir() + File.separator + "wrapper.log");
         File tempLog;
         if(wrapperFile.exists()){
-            tempLog = new File(System.getProperty("java.io.tmpdir") + File.separator + UUID.randomUUID().toString() + ".system_logs.idb");
+            tempLog = new File(System.getProperty("java.io.tmpdir") + File.separator + UUID.randomUUID().toString() + ".wrapper.log");
             try {
                 FileUtils.copyFile(wrapperFile, tempLog);
             } catch (IOException e) {
@@ -89,7 +89,7 @@ public class GetLogsServiceImpl implements GetLogsService, SecuredEntityImplemen
         }
         else{
             logger.warn(String.format("%s does not exist. Log file will not be sent", wrapperFile.getAbsolutePath()));
-            return GetLogsService.FAIL_MSG + ": system_logs.idb file was not found";
+            return GetLogsService.FAIL_MSG + ": wrapper.log file was not found";
         }
 
         String finalResult;
@@ -116,7 +116,7 @@ public class GetLogsServiceImpl implements GetLogsService, SecuredEntityImplemen
         // The passed wrapperFilePath holds the path to the streamed wrapper.log file on the local system.
         // From here, you can move the file to an archived location as you see fit. You will need to return
         // a success or fail message so the original caller can report on the task execution.
-        logger.info(String.format("Streamed system_logs.idb file for server '%s' is available here: %s",
+        logger.info(String.format("Streamed wrapper.log file for server '%s' is available here: %s",
                 sourceServerId.toDescriptiveString(),
                 wrapperFilePath));
 

--- a/gateway-network-function/gateway-network-function-gateway/src/main/java/com/inductiveautomation/ignition/examples/task/GetWrapperLogTaskType.java
+++ b/gateway-network-function/gateway-network-function-gateway/src/main/java/com/inductiveautomation/ignition/examples/task/GetWrapperLogTaskType.java
@@ -24,8 +24,12 @@ public class GetWrapperLogTaskType extends AbstractTaskType {
     public static final String BUNDLE_KEY = "remotelogging.tasks";
     public static final String TYPE_ID = "getwrapperlog";
 
-    public GetWrapperLogTaskType() {
-        super(GatewayHook.TASK_OWNERID, TYPE_ID, BUNDLE_KEY, false, false);
+    private GatewayContext context;
+
+
+    public GetWrapperLogTaskType(GatewayContext context) {
+       super(GatewayHook.TASK_OWNERID, TYPE_ID, BUNDLE_KEY, false, false);
+        this.context = context;
     }
 
     /**
@@ -63,7 +67,7 @@ public class GetWrapperLogTaskType extends AbstractTaskType {
             }
         };
 
-        model.add(new RemoteServerSelectionStep(stepModel));
+        model.add(new RemoteServerSelectionStep(stepModel, context));
     }
 
     /**

--- a/gateway-network-function/gateway-network-function-gateway/src/main/java/com/inductiveautomation/ignition/examples/task/GetWrapperLogTaskType.java
+++ b/gateway-network-function/gateway-network-function-gateway/src/main/java/com/inductiveautomation/ignition/examples/task/GetWrapperLogTaskType.java
@@ -24,12 +24,8 @@ public class GetWrapperLogTaskType extends AbstractTaskType {
     public static final String BUNDLE_KEY = "remotelogging.tasks";
     public static final String TYPE_ID = "getwrapperlog";
 
-    private GatewayContext context;
-
-
-    public GetWrapperLogTaskType(GatewayContext context) {
-       super(GatewayHook.TASK_OWNERID, TYPE_ID, BUNDLE_KEY, false, false);
-        this.context = context;
+    public GetWrapperLogTaskType() {
+        super(GatewayHook.TASK_OWNERID, TYPE_ID, BUNDLE_KEY, false, false);
     }
 
     /**
@@ -67,7 +63,7 @@ public class GetWrapperLogTaskType extends AbstractTaskType {
             }
         };
 
-        model.add(new RemoteServerSelectionStep(stepModel, context));
+        model.add(new RemoteServerSelectionStep(stepModel));
     }
 
     /**

--- a/gateway-network-function/gateway-network-function-gateway/src/main/java/com/inductiveautomation/ignition/examples/task/RemoteServerSelectionStep.java
+++ b/gateway-network-function/gateway-network-function-gateway/src/main/java/com/inductiveautomation/ignition/examples/task/RemoteServerSelectionStep.java
@@ -7,6 +7,7 @@ import java.util.List;
 import com.inductiveautomation.ignition.common.BundleUtil;
 import com.inductiveautomation.ignition.gateway.gan.GatewayNetworkManager;
 import com.inductiveautomation.ignition.gateway.model.GatewayContext;
+import com.inductiveautomation.ignition.gateway.model.IgnitionWebApp;
 import com.inductiveautomation.metro.api.ServerId;
 import org.apache.wicket.Application;
 import org.apache.wicket.extensions.wizard.WizardStep;
@@ -100,7 +101,7 @@ public class RemoteServerSelectionStep extends WizardStep {
         List<SimpleRemoteGateway> gateways = new ArrayList<>();
 
         // Determine all known remote Gateways
-        GatewayContext context = (GatewayContext) Application.get();
+        GatewayContext context = (((IgnitionWebApp) Application.get()).getContext());
         GatewayNetworkManager gn = context.getGatewayAreaNetworkManager();
         List<ServerId> servers = gn.getKnownServers();
         for(ServerId server: servers){

--- a/gateway-network-function/gateway-network-function-gateway/src/main/java/com/inductiveautomation/ignition/examples/task/RemoteServerSelectionStep.java
+++ b/gateway-network-function/gateway-network-function-gateway/src/main/java/com/inductiveautomation/ignition/examples/task/RemoteServerSelectionStep.java
@@ -8,7 +8,6 @@ import com.inductiveautomation.ignition.common.BundleUtil;
 import com.inductiveautomation.ignition.gateway.gan.GatewayNetworkManager;
 import com.inductiveautomation.ignition.gateway.model.GatewayContext;
 import com.inductiveautomation.metro.api.ServerId;
-import org.apache.wicket.Application;
 import org.apache.wicket.extensions.wizard.WizardStep;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.form.CheckBox;
@@ -29,7 +28,7 @@ public class RemoteServerSelectionStep extends WizardStep {
     private List<SimpleRemoteGateway> gateways;
     private String accessKey;
 
-    public RemoteServerSelectionStep(IModel<RemoteGatewaySelection> settings){
+    public RemoteServerSelectionStep(IModel<RemoteGatewaySelection> settings, GatewayContext context){
         super(BundleUtil.get().getString(TITLE), null, settings);
 
         // A form is required when using elements like checkboxes
@@ -39,7 +38,7 @@ public class RemoteServerSelectionStep extends WizardStep {
         // The gateways list is serialized when the Previous button is clicked in the wizard. This functionality
         // allows the checkbox selections to be preserved when returning to this page in the wizard.
         if(gateways == null){
-            gateways = loadRemoteGateways(settings.getObject().getSelectedGateways());
+            gateways = loadRemoteGateways(settings.getObject().getSelectedGateways(), context);
         }
 
         this.accessKey = settings.getObject().getAccessKey();
@@ -96,13 +95,12 @@ public class RemoteServerSelectionStep extends WizardStep {
      * @param initialSelectedGateways
      * @return
      */
-    private List<SimpleRemoteGateway> loadRemoteGateways(List<String> initialSelectedGateways){
+    private List<SimpleRemoteGateway> loadRemoteGateways(List<String> initialSelectedGateways, GatewayContext context) {
         List<SimpleRemoteGateway> gateways = new ArrayList<>();
 
-        // Determine all known remote Gateways
-        GatewayContext context = (GatewayContext) Application.get();
         GatewayNetworkManager gn = context.getGatewayAreaNetworkManager();
         List<ServerId> servers = gn.getKnownServers();
+
         for(ServerId server: servers){
             SimpleRemoteGateway sg = new SimpleRemoteGateway(server.getServerName(), gn.getServer(server).getState().toString());
             if(initialSelectedGateways.contains(server.getServerName())){

--- a/gateway-network-function/gateway-network-function-gateway/src/main/java/com/inductiveautomation/ignition/examples/task/RemoteServerSelectionStep.java
+++ b/gateway-network-function/gateway-network-function-gateway/src/main/java/com/inductiveautomation/ignition/examples/task/RemoteServerSelectionStep.java
@@ -8,6 +8,7 @@ import com.inductiveautomation.ignition.common.BundleUtil;
 import com.inductiveautomation.ignition.gateway.gan.GatewayNetworkManager;
 import com.inductiveautomation.ignition.gateway.model.GatewayContext;
 import com.inductiveautomation.metro.api.ServerId;
+import org.apache.wicket.Application;
 import org.apache.wicket.extensions.wizard.WizardStep;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.form.CheckBox;
@@ -28,7 +29,7 @@ public class RemoteServerSelectionStep extends WizardStep {
     private List<SimpleRemoteGateway> gateways;
     private String accessKey;
 
-    public RemoteServerSelectionStep(IModel<RemoteGatewaySelection> settings, GatewayContext context){
+    public RemoteServerSelectionStep(IModel<RemoteGatewaySelection> settings){
         super(BundleUtil.get().getString(TITLE), null, settings);
 
         // A form is required when using elements like checkboxes
@@ -38,7 +39,7 @@ public class RemoteServerSelectionStep extends WizardStep {
         // The gateways list is serialized when the Previous button is clicked in the wizard. This functionality
         // allows the checkbox selections to be preserved when returning to this page in the wizard.
         if(gateways == null){
-            gateways = loadRemoteGateways(settings.getObject().getSelectedGateways(), context);
+            gateways = loadRemoteGateways(settings.getObject().getSelectedGateways());
         }
 
         this.accessKey = settings.getObject().getAccessKey();
@@ -95,12 +96,13 @@ public class RemoteServerSelectionStep extends WizardStep {
      * @param initialSelectedGateways
      * @return
      */
-    private List<SimpleRemoteGateway> loadRemoteGateways(List<String> initialSelectedGateways, GatewayContext context) {
+    private List<SimpleRemoteGateway> loadRemoteGateways(List<String> initialSelectedGateways){
         List<SimpleRemoteGateway> gateways = new ArrayList<>();
 
+        // Determine all known remote Gateways
+        GatewayContext context = (GatewayContext) Application.get();
         GatewayNetworkManager gn = context.getGatewayAreaNetworkManager();
         List<ServerId> servers = gn.getKnownServers();
-
         for(ServerId server: servers){
             SimpleRemoteGateway sg = new SimpleRemoteGateway(server.getServerName(), gn.getServer(server).getState().toString());
             if(initialSelectedGateways.contains(server.getServerName())){

--- a/gateway-network-function/pom.xml
+++ b/gateway-network-function/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.inductiveautomation.examples</groupId>
     <artifactId>gateway-network-function</artifactId>
     <packaging>pom</packaging>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
 
     <properties>
         <ignition-platform-version>8.1.0-SNAPSHOT</ignition-platform-version>

--- a/gateway-network-function/readme.md
+++ b/gateway-network-function/readme.md
@@ -11,11 +11,11 @@ You will need to install the module on two separate Gateways. You can create a s
 ```
 import datetime
 
-servers = ["ide_controller"]
+servers = ["agent"]
 startTime = datetime.datetime.now() - datetime.timedelta(hours=3)
 
 map = system.example.getRemoteLogEntries(servers, startTime)
-serverLogs = map["ide_controller"]
+serverLogs = map["agent"]
 for row in range(serverLogs.rowCount):
 	printable = {
 	'level': serverLogs.getValueAt(row, "level"), 

--- a/gateway-webpage/gateway-webpage-build/pom.xml
+++ b/gateway-webpage/gateway-webpage-build/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>gateway-webpage</artifactId>
         <groupId>com.inductiveautomation.ignition.examples.hce</groupId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-webpage-build</artifactId>

--- a/gateway-webpage/gateway-webpage-gateway/pom.xml
+++ b/gateway-webpage/gateway-webpage-gateway/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>gateway-webpage</artifactId>
         <groupId>com.inductiveautomation.ignition.examples.hce</groupId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-webpage-gateway</artifactId>

--- a/gateway-webpage/gateway-webpage-gateway/pom.xml
+++ b/gateway-webpage/gateway-webpage-gateway/pom.xml
@@ -45,8 +45,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.2</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/gateway-webpage/pom.xml
+++ b/gateway-webpage/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.inductiveautomation.ignition.examples.hce</groupId>
     <artifactId>gateway-webpage</artifactId>
     <packaging>pom</packaging>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
 
     <modules>
         <module>gateway-webpage-gateway</module>

--- a/managed-tag-provider/managed-tag-provider-build/pom.xml
+++ b/managed-tag-provider/managed-tag-provider-build/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.inductiveautomation.ignition.examples</groupId>
         <artifactId>managed-tag-provider</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>managed-tag-provider-build</artifactId>

--- a/managed-tag-provider/managed-tag-provider-gateway/pom.xml
+++ b/managed-tag-provider/managed-tag-provider-gateway/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.inductiveautomation.ignition.examples</groupId>
         <artifactId>managed-tag-provider</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>managed-tag-provider-gateway</artifactId>

--- a/managed-tag-provider/managed-tag-provider-gateway/pom.xml
+++ b/managed-tag-provider/managed-tag-provider-gateway/pom.xml
@@ -37,8 +37,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.2</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/managed-tag-provider/pom.xml
+++ b/managed-tag-provider/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.inductiveautomation.ignition.examples</groupId>
     <artifactId>managed-tag-provider</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/opc-ua-device/opc-ua-device-build/pom.xml
+++ b/opc-ua-device/opc-ua-device-build/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.inductiveautomation.examples</groupId>
         <artifactId>opc-ua-device</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>opc-ua-device-build</artifactId>

--- a/opc-ua-device/opc-ua-device-gateway/pom.xml
+++ b/opc-ua-device/opc-ua-device-gateway/pom.xml
@@ -49,8 +49,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.2</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/opc-ua-device/opc-ua-device-gateway/pom.xml
+++ b/opc-ua-device/opc-ua-device-gateway/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.inductiveautomation.examples</groupId>
         <artifactId>opc-ua-device</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>opc-ua-device-gateway</artifactId>

--- a/opc-ua-device/pom.xml
+++ b/opc-ua-device/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.inductiveautomation.examples</groupId>
     <artifactId>opc-ua-device</artifactId>
     <packaging>pom</packaging>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
 
     <modules>
         <module>opc-ua-device-build</module>

--- a/perspective-component/build.gradle.kts
+++ b/perspective-component/build.gradle.kts
@@ -50,6 +50,7 @@ ignitionModule {
             "org.fakester.designer.RadDesignerHook" to "D"
         )
     )
+    skipModlSigning.set(true)
 }
 
 

--- a/perspective-component/common/build.gradle.kts
+++ b/perspective-component/common/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(11))
+        languageVersion.set(JavaLanguageVersion.of(17))
     }
 }
 

--- a/perspective-component/designer/build.gradle.kts
+++ b/perspective-component/designer/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(11))
+        languageVersion.set(JavaLanguageVersion.of(17))
     }
 }
 

--- a/perspective-component/gateway/build.gradle.kts
+++ b/perspective-component/gateway/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(11))
+        languageVersion.set(JavaLanguageVersion.of(17))
     }
 }
 

--- a/project-resource/gradle/libs.versions.toml
+++ b/project-resource/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 ignition = "8.1.26"
-java = "11"
+java = "17"
 
 [plugins]
 modl = { id = "io.ia.sdk.modl", version = "0.1.1" }

--- a/readme.md
+++ b/readme.md
@@ -53,7 +53,7 @@ The Gradle Plugin is published to the [Gradle Plugin Portal](https://plugins.gra
 These requirements generally apply to both Gradle and Maven build tools.
 
 * Java Development Kit (JDK) 17 installed. You can download it on the [Java SDK Downloads](http://www.oracle.com/technetwork/java/javase/downloads/index-jsp-138363.html) page.  Licensed/TCK tested JDK vendors such as Adoptium, Azul Zulu, etc, are generally suitable JDKs as well.
-* A running, 8.0+ version of Ignition to test your module in. If you don't already have Ignition installed head to the Inductive Automation [downloads](https://www.inductiveautomation.com/downloads/) page, download the correct package for your system and follow the installation instructions to get a gateway up and running.
+* A running, 8.1.33+ version of Ignition to test your module in. If you don't already have Ignition installed head to the Inductive Automation [downloads](https://www.inductiveautomation.com/downloads/) page, download the correct package for your system and follow the installation instructions to get a gateway up and running.
 * For development convenience, you may want to allow unsigned modules. Open the `ignition.conf` file in the `data/` directory, then in the `wrapper.java.additional` section add a line like: `wrapper.java.additional.7=-Dignition.allowunsignedmodules=true` (the index does not matter).
 
 ## Getting Started

--- a/readme.md
+++ b/readme.md
@@ -52,7 +52,7 @@ The Gradle Plugin is published to the [Gradle Plugin Portal](https://plugins.gra
 
 These requirements generally apply to both Gradle and Maven build tools.
 
-* Java Development Kit (JDK) 11 installed. You can download it on the [Java SDK Downloads](http://www.oracle.com/technetwork/java/javase/downloads/index-jsp-138363.html) page.  Licensed/TCK tested JDK vendors such as Adoptium, Azul Zulu, etc, are generally suitable JDKs as well.
+* Java Development Kit (JDK) 17 installed. You can download it on the [Java SDK Downloads](http://www.oracle.com/technetwork/java/javase/downloads/index-jsp-138363.html) page.  Licensed/TCK tested JDK vendors such as Adoptium, Azul Zulu, etc, are generally suitable JDKs as well.
 * A running, 8.0+ version of Ignition to test your module in. If you don't already have Ignition installed head to the Inductive Automation [downloads](https://www.inductiveautomation.com/downloads/) page, download the correct package for your system and follow the installation instructions to get a gateway up and running.
 * For development convenience, you may want to allow unsigned modules. Open the `ignition.conf` file in the `data/` directory, then in the `wrapper.java.additional` section add a line like: `wrapper.java.additional.7=-Dignition.allowunsignedmodules=true` (the index does not matter).
 

--- a/report-component/pom.xml
+++ b/report-component/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.inductiveautomation.ignition.examples</groupId>
     <artifactId>report-component</artifactId>
     <packaging>pom</packaging>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
 
     <modules>
         <module>report-component-build</module>

--- a/report-component/report-component-build/pom.xml
+++ b/report-component/report-component-build/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>report-component</artifactId>
         <groupId>com.inductiveautomation.ignition.examples</groupId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>report-component-build</artifactId>

--- a/report-component/report-component-common/pom.xml
+++ b/report-component/report-component-common/pom.xml
@@ -29,8 +29,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.3</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/report-component/report-component-common/pom.xml
+++ b/report-component/report-component-common/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>report-component</artifactId>
         <groupId>com.inductiveautomation.ignition.examples</groupId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>report-component-common</artifactId>

--- a/report-component/report-component-designer/pom.xml
+++ b/report-component/report-component-designer/pom.xml
@@ -41,8 +41,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.3</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/report-component/report-component-designer/pom.xml
+++ b/report-component/report-component-designer/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>report-component</artifactId>
         <groupId>com.inductiveautomation.ignition.examples</groupId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>report-component-designer</artifactId>

--- a/report-component/report-component-gateway/pom.xml
+++ b/report-component/report-component-gateway/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>report-component</artifactId>
         <groupId>com.inductiveautomation.ignition.examples</groupId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>report-component-gateway</artifactId>

--- a/report-component/report-component-gateway/pom.xml
+++ b/report-component/report-component-gateway/pom.xml
@@ -34,8 +34,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.3</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/report-datasource/pom.xml
+++ b/report-datasource/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.inductiveautomation.ignition.examples</groupId>
     <artifactId>report-datasource</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/report-datasource/pom.xml
+++ b/report-datasource/pom.xml
@@ -34,8 +34,8 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.3</version>
                     <configuration>
-                        <source>11</source>
-                        <target>11</target>
+                        <source>17</source>
+                        <target>17</target>
                     </configuration>
                 </plugin>
             </plugins>

--- a/report-datasource/report-datasource-build/pom.xml
+++ b/report-datasource/report-datasource-build/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>report-datasource</artifactId>
         <groupId>com.inductiveautomation.ignition.examples</groupId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>report-datasource-build</artifactId>

--- a/report-datasource/report-datasource-common/pom.xml
+++ b/report-datasource/report-datasource-common/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>report-datasource</artifactId>
         <groupId>com.inductiveautomation.ignition.examples</groupId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>report-datasource-common</artifactId>

--- a/report-datasource/report-datasource-designer/pom.xml
+++ b/report-datasource/report-datasource-designer/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>report-datasource</artifactId>
         <groupId>com.inductiveautomation.ignition.examples</groupId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>report-datasource-designer</artifactId>

--- a/report-datasource/report-datasource-gateway/pom.xml
+++ b/report-datasource/report-datasource-gateway/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>report-datasource</artifactId>
         <groupId>com.inductiveautomation.ignition.examples</groupId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>report-datasource-gateway</artifactId>

--- a/scripting-function/pom.xml
+++ b/scripting-function/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.inductiveautomation.ignition.examples</groupId>
     <artifactId>scripting-function</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/scripting-function/scripting-function-build/pom.xml
+++ b/scripting-function/scripting-function-build/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>scripting-function</artifactId>
         <groupId>com.inductiveautomation.ignition.examples</groupId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>scripting-function-build</artifactId>

--- a/scripting-function/scripting-function-client/pom.xml
+++ b/scripting-function/scripting-function-client/pom.xml
@@ -61,8 +61,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.2</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/scripting-function/scripting-function-client/pom.xml
+++ b/scripting-function/scripting-function-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>scripting-function</artifactId>
         <groupId>com.inductiveautomation.ignition.examples</groupId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>scripting-function-client</artifactId>

--- a/scripting-function/scripting-function-common/pom.xml
+++ b/scripting-function/scripting-function-common/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>scripting-function</artifactId>
         <groupId>com.inductiveautomation.ignition.examples</groupId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>scripting-function-common</artifactId>

--- a/scripting-function/scripting-function-common/pom.xml
+++ b/scripting-function/scripting-function-common/pom.xml
@@ -28,8 +28,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.2</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/scripting-function/scripting-function-designer/pom.xml
+++ b/scripting-function/scripting-function-designer/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>scripting-function</artifactId>
         <groupId>com.inductiveautomation.ignition.examples</groupId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>scripting-function-designer</artifactId>

--- a/scripting-function/scripting-function-designer/pom.xml
+++ b/scripting-function/scripting-function-designer/pom.xml
@@ -59,8 +59,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.2</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/scripting-function/scripting-function-gateway/pom.xml
+++ b/scripting-function/scripting-function-gateway/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>scripting-function</artifactId>
         <groupId>com.inductiveautomation.ignition.examples</groupId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>scripting-function-gateway</artifactId>

--- a/scripting-function/scripting-function-gateway/pom.xml
+++ b/scripting-function/scripting-function-gateway/pom.xml
@@ -47,8 +47,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.2</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/slack-alarm-notification/pom.xml
+++ b/slack-alarm-notification/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.inductiveautomation.ignition.examples</groupId>
     <artifactId>slack-alarm-notification</artifactId>
     <packaging>pom</packaging>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
 
     <modules>
         <module>slack-notification-build</module>

--- a/slack-alarm-notification/slack-notification-build/pom.xml
+++ b/slack-alarm-notification/slack-notification-build/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.inductiveautomation.ignition.examples</groupId>
         <artifactId>slack-alarm-notification</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>slack-notification-build</artifactId>

--- a/slack-alarm-notification/slack-notification-gateway/pom.xml
+++ b/slack-alarm-notification/slack-notification-gateway/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.inductiveautomation.ignition.examples</groupId>
         <artifactId>slack-alarm-notification</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>slack-notification-gateway</artifactId>

--- a/slack-alarm-notification/slack-notification-gateway/pom.xml
+++ b/slack-alarm-notification/slack-notification-gateway/pom.xml
@@ -52,8 +52,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.2</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/vision-component/ce-client/pom.xml
+++ b/vision-component/ce-client/pom.xml
@@ -61,8 +61,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.2</version>
                 <configuration>
-                    <source>11</source>
-                    <target>11</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/vision-component/ce-designer/pom.xml
+++ b/vision-component/ce-designer/pom.xml
@@ -59,8 +59,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.2</version>
                 <configuration>
-                    <source>11</source>
-                    <target>11</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
Examples have been updated to target Java 17 as to be consistent with the Ignition Platform. 


Fixes the following Internal Ticket Numbers:
IGN-8380