### PR TITLE
IGN-13766: Remove warnings for slack alarm notification example

### DIFF
--- a/slack-alarm-notification/README.md
+++ b/slack-alarm-notification/README.md
@@ -1,7 +1,4 @@
 # Slack Alarm Notification Example
-> [!WARNING]
-> This example uses a custom contact type, which is not currently accessible via the UI; it must be added to the user's profile manually (see  [Using The Resource Configuration](#using-the-resource-configuration)). 
-
 ### Overview
 
 Provides a framework for implementing a custom alarm notification system.
@@ -14,9 +11,6 @@ webhook, you can add the webhook as a `SLACK_WEBHOOK` Contact Type under your us
 of the following methods:
 
 #### Using the UI
-> [!WARNING]
-> Currently you cannot add the contact type through this method, use the method outlined in [Using The Resource Configuration](#using-the-resource-configuration) instead.
-
 Login to the Gateway, navigate to "Platform > Security > User Sources > [YOUR_USER_SOURCE]," select "Manage Users"
 under the dropdown next to the User Source you want to use, select your user and then "Edit," and add the "Slack"
 Contact Type where the value is the URL of the webhook.

--- a/slack-alarm-notification/slack-notification-gateway/src/main/resources/io/ia/ignition/sdk/examples/slack/SlackNotification.properties
+++ b/slack-alarm-notification/slack-notification-gateway/src/main/resources/io/ia/ignition/sdk/examples/slack/SlackNotification.properties
@@ -26,4 +26,4 @@ Category.Audit=Auditing
 AuditProfile.Name=Audit Profile
 AuditProfile.Desc=If an audit profile is selected, events such as phone calls and acknowledgements will be stored to the audit system. Note that alarm acknowledgements are also stored to the alarm journal.
 
-ContactType.Slack=Slack Webhook URL
+ContactType.Slack=Slack


### PR DESCRIPTION
* Remove Warnings from the slack-alarm-notification README.md file. 
* Update ContactType from "Slack Webhook URL" to "Slack"
    <img width="294" height="278" alt="image" src="https://github.com/user-attachments/assets/ef57f162-a82f-4886-997d-1efabd6b76d9" />
