### PR TITLE
Broken link pluginRepository vision-component

### DIFF
--- a/vision-component/pom.xml
+++ b/vision-component/pom.xml
@@ -25,7 +25,7 @@
     <pluginRepositories>
         <pluginRepository>
             <id>releases</id>
-            <url>https://nexus.inductiveautomation.com/repository/inductiveautomation-releases.</url>
+            <url>https://nexus.inductiveautomation.com/repository/inductiveautomation-releases</url>
             <releases>
                 <enabled>true</enabled>
                 <updatePolicy>always</updatePolicy>


### PR DESCRIPTION
Fixed link inside pom.xml in the vision-component module example.