### PR TITLE
Migrate to jspecify nullability annotations and bump SDK to 8.3.4-SNAPSHOT

### DIFF
--- a/event-stream-handler/pom.xml
+++ b/event-stream-handler/pom.xml
@@ -17,7 +17,7 @@
     </modules>
 
     <properties>
-        <ignition-platform-version>8.3.4-SNAPSHOT</ignition-platform-version>
+        <ignition-platform-version>8.3.4</ignition-platform-version>
         <ignition-sdk-version>${ignition-platform-version}</ignition-sdk-version>
         <module-name>Event Stream Handler Example</module-name>
         <module-description>Adds a simple Event Stream Handler to the Event Stream module.</module-description>

--- a/event-stream-handler/pom.xml
+++ b/event-stream-handler/pom.xml
@@ -17,7 +17,7 @@
     </modules>
 
     <properties>
-        <ignition-platform-version>8.3.0</ignition-platform-version>
+        <ignition-platform-version>8.3.4-SNAPSHOT</ignition-platform-version>
         <ignition-sdk-version>${ignition-platform-version}</ignition-sdk-version>
         <module-name>Event Stream Handler Example</module-name>
         <module-description>Adds a simple Event Stream Handler to the Event Stream module.</module-description>

--- a/event-stream-source/pom.xml
+++ b/event-stream-source/pom.xml
@@ -17,7 +17,7 @@
     </modules>
 
     <properties>
-        <ignition-platform-version>8.3.4-SNAPSHOT</ignition-platform-version>
+        <ignition-platform-version>8.3.4</ignition-platform-version>
         <ignition-sdk-version>${ignition-platform-version}</ignition-sdk-version>
         <module-name>Event Stream Source Example</module-name>
         <module-description>Adds a simple Event Stream Source to the Event Stream module.</module-description>

--- a/event-stream-source/pom.xml
+++ b/event-stream-source/pom.xml
@@ -17,7 +17,7 @@
     </modules>
 
     <properties>
-        <ignition-platform-version>8.3.0</ignition-platform-version>
+        <ignition-platform-version>8.3.4-SNAPSHOT</ignition-platform-version>
         <ignition-sdk-version>${ignition-platform-version}</ignition-sdk-version>
         <module-name>Event Stream Source Example</module-name>
         <module-description>Adds a simple Event Stream Source to the Event Stream module.</module-description>

--- a/expression-function/pom.xml
+++ b/expression-function/pom.xml
@@ -10,7 +10,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <ignition-platform-version>8.3.4-SNAPSHOT</ignition-platform-version>
+        <ignition-platform-version>8.3.4</ignition-platform-version>
         <ignition-sdk-version>${ignition-platform-version}</ignition-sdk-version>
         <module-name>Expression Function Example</module-name>
         <module-description>Implements a simple expression function in the client, designer, and gateway scope.</module-description>

--- a/expression-function/pom.xml
+++ b/expression-function/pom.xml
@@ -10,7 +10,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <ignition-platform-version>8.3.0</ignition-platform-version>
+        <ignition-platform-version>8.3.4-SNAPSHOT</ignition-platform-version>
         <ignition-sdk-version>${ignition-platform-version}</ignition-sdk-version>
         <module-name>Expression Function Example</module-name>
         <module-description>Implements a simple expression function in the client, designer, and gateway scope.</module-description>

--- a/gateway-network-function/pom.xml
+++ b/gateway-network-function/pom.xml
@@ -10,7 +10,7 @@
     <version>2.0.1-SNAPSHOT</version>
 
     <properties>
-        <ignition-platform-version>8.3.4-SNAPSHOT</ignition-platform-version>
+        <ignition-platform-version>8.3.4</ignition-platform-version>
         <ignition-sdk-version>${ignition-platform-version}</ignition-sdk-version>
         <module-name>Gateway Network Function Example</module-name>
         <module-description>Provides examples of gateway network functions</module-description>

--- a/gateway-network-function/pom.xml
+++ b/gateway-network-function/pom.xml
@@ -10,7 +10,7 @@
     <version>2.0.1-SNAPSHOT</version>
 
     <properties>
-        <ignition-platform-version>8.3.0</ignition-platform-version>
+        <ignition-platform-version>8.3.4-SNAPSHOT</ignition-platform-version>
         <ignition-sdk-version>${ignition-platform-version}</ignition-sdk-version>
         <module-name>Gateway Network Function Example</module-name>
         <module-description>Provides examples of gateway network functions</module-description>

--- a/managed-tag-provider/pom.xml
+++ b/managed-tag-provider/pom.xml
@@ -15,7 +15,7 @@
     </modules>
 
     <properties>
-        <ignition-platform-version>8.3.0</ignition-platform-version>
+        <ignition-platform-version>8.3.4-SNAPSHOT</ignition-platform-version>
         <ignition-sdk-version>${ignition-platform-version}</ignition-sdk-version>
         <module-name>Managed Tag Provider Example</module-name>
         <module-description>Implements the Managed Tag Provider interface to expose tags in Ignition.</module-description>

--- a/managed-tag-provider/pom.xml
+++ b/managed-tag-provider/pom.xml
@@ -15,7 +15,7 @@
     </modules>
 
     <properties>
-        <ignition-platform-version>8.3.4-SNAPSHOT</ignition-platform-version>
+        <ignition-platform-version>8.3.4</ignition-platform-version>
         <ignition-sdk-version>${ignition-platform-version}</ignition-sdk-version>
         <module-name>Managed Tag Provider Example</module-name>
         <module-description>Implements the Managed Tag Provider interface to expose tags in Ignition.</module-description>

--- a/opc-ua-device/pom.xml
+++ b/opc-ua-device/pom.xml
@@ -15,7 +15,7 @@
     </modules>
 
     <properties>
-        <ignition-platform-version>8.3.4-SNAPSHOT</ignition-platform-version>
+        <ignition-platform-version>8.3.4</ignition-platform-version>
         <ignition-sdk-version>${ignition-platform-version}</ignition-sdk-version>
         <module-name>OPC UA Device Example</module-name>
         <module-description>Shows how to implement a new OPC UA device type</module-description>

--- a/opc-ua-device/pom.xml
+++ b/opc-ua-device/pom.xml
@@ -15,7 +15,7 @@
     </modules>
 
     <properties>
-        <ignition-platform-version>8.3.0</ignition-platform-version>
+        <ignition-platform-version>8.3.4-SNAPSHOT</ignition-platform-version>
         <ignition-sdk-version>${ignition-platform-version}</ignition-sdk-version>
         <module-name>OPC UA Device Example</module-name>
         <module-description>Shows how to implement a new OPC UA device type</module-description>

--- a/perspective-component-minimal/gradle/libs.versions.toml
+++ b/perspective-component-minimal/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-    ignition = "8.3.0"
+    ignition = "8.3.4-SNAPSHOT"
 
 [libraries]
     # Dependencies provided by the Ignition SDK, they all reference the 'ignition' version

--- a/perspective-component-minimal/gradle/libs.versions.toml
+++ b/perspective-component-minimal/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-    ignition = "8.3.4-SNAPSHOT"
+    ignition = "8.3.4"
 
 [libraries]
     # Dependencies provided by the Ignition SDK, they all reference the 'ignition' version

--- a/perspective-component/gradle/libs.versions.toml
+++ b/perspective-component/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-    ignition = "8.3.0"
+    ignition = "8.3.4-SNAPSHOT"
 
 [libraries]
     # Dependencies provided by the Ignition SDK, they all reference the 'ignition' version

--- a/perspective-component/gradle/libs.versions.toml
+++ b/perspective-component/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-    ignition = "8.3.4-SNAPSHOT"
+    ignition = "8.3.4"
 
 [libraries]
     # Dependencies provided by the Ignition SDK, they all reference the 'ignition' version

--- a/project-resource/gradle/libs.versions.toml
+++ b/project-resource/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-ignition = "8.3.4-SNAPSHOT"
+ignition = "8.3.4"
 java = "17"
 
 [plugins]

--- a/project-resource/gradle/libs.versions.toml
+++ b/project-resource/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-ignition = "8.3.0"
+ignition = "8.3.4-SNAPSHOT"
 java = "17"
 
 [plugins]

--- a/report-component/pom.xml
+++ b/report-component/pom.xml
@@ -17,7 +17,7 @@
     </modules>
 
     <properties>
-        <ignition-platform-version>8.3.0</ignition-platform-version>
+        <ignition-platform-version>8.3.4-SNAPSHOT</ignition-platform-version>
         <ignition-sdk-version>${ignition-platform-version}</ignition-sdk-version>
         <module-name>Report Component Example</module-name>
         <module-description>Adds a simple 'Smiley Face' component to the Reporting module.</module-description>

--- a/report-component/pom.xml
+++ b/report-component/pom.xml
@@ -17,7 +17,7 @@
     </modules>
 
     <properties>
-        <ignition-platform-version>8.3.4-SNAPSHOT</ignition-platform-version>
+        <ignition-platform-version>8.3.4</ignition-platform-version>
         <ignition-sdk-version>${ignition-platform-version}</ignition-sdk-version>
         <module-name>Report Component Example</module-name>
         <module-description>Adds a simple 'Smiley Face' component to the Reporting module.</module-description>

--- a/report-datasource/pom.xml
+++ b/report-datasource/pom.xml
@@ -17,7 +17,7 @@
     </modules>
 
     <properties>
-        <ignition-platform-version>8.3.1-SNAPSHOT</ignition-platform-version>
+        <ignition-platform-version>8.3.4-SNAPSHOT</ignition-platform-version>
         <ignition-sdk-version>${ignition-platform-version}</ignition-sdk-version>
         <module-name>Report Datasource Example</module-name>
         <module-description>Adds a REST/Json datasource to Ignition's reporting module as a datasource

--- a/report-datasource/pom.xml
+++ b/report-datasource/pom.xml
@@ -17,7 +17,7 @@
     </modules>
 
     <properties>
-        <ignition-platform-version>8.3.4-SNAPSHOT</ignition-platform-version>
+        <ignition-platform-version>8.3.4</ignition-platform-version>
         <ignition-sdk-version>${ignition-platform-version}</ignition-sdk-version>
         <module-name>Report Datasource Example</module-name>
         <module-description>Adds a REST/Json datasource to Ignition's reporting module as a datasource

--- a/scripting-function/pom.xml
+++ b/scripting-function/pom.xml
@@ -18,7 +18,7 @@
     </modules>
 
     <properties>
-        <ignition-platform-version>8.3.0</ignition-platform-version>
+        <ignition-platform-version>8.3.4-SNAPSHOT</ignition-platform-version>
         <ignition-sdk-version>${ignition-platform-version}</ignition-sdk-version>
         <module-name>Scripting Function Example</module-name>
         <module-description>Adds a simple scripting function to the Client and Gateway</module-description>

--- a/scripting-function/pom.xml
+++ b/scripting-function/pom.xml
@@ -18,7 +18,7 @@
     </modules>
 
     <properties>
-        <ignition-platform-version>8.3.4-SNAPSHOT</ignition-platform-version>
+        <ignition-platform-version>8.3.4</ignition-platform-version>
         <ignition-sdk-version>${ignition-platform-version}</ignition-sdk-version>
         <module-name>Scripting Function Example</module-name>
         <module-description>Adds a simple scripting function to the Client and Gateway</module-description>

--- a/secret-provider/pom.xml
+++ b/secret-provider/pom.xml
@@ -15,7 +15,7 @@
     </modules>
 
     <properties>
-        <ignition-platform-version>8.3.4-SNAPSHOT</ignition-platform-version>
+        <ignition-platform-version>8.3.4</ignition-platform-version>
         <ignition-sdk-version>${ignition-platform-version}</ignition-sdk-version>
         <module-name>MongoDB Secret Provider Example</module-name>
         <module-description>Adds a secret provider backed by MongoDB to Ignition.</module-description>

--- a/secret-provider/pom.xml
+++ b/secret-provider/pom.xml
@@ -15,7 +15,7 @@
     </modules>
 
     <properties>
-        <ignition-platform-version>8.3.0</ignition-platform-version>
+        <ignition-platform-version>8.3.4-SNAPSHOT</ignition-platform-version>
         <ignition-sdk-version>${ignition-platform-version}</ignition-sdk-version>
         <module-name>MongoDB Secret Provider Example</module-name>
         <module-description>Adds a secret provider backed by MongoDB to Ignition.</module-description>

--- a/slack-alarm-notification/pom.xml
+++ b/slack-alarm-notification/pom.xml
@@ -15,7 +15,7 @@
     </modules>
 
     <properties>
-        <ignition-platform-version>8.3.0</ignition-platform-version>
+        <ignition-platform-version>8.3.4-SNAPSHOT</ignition-platform-version>
         <ignition-sdk-version>${ignition-platform-version}</ignition-sdk-version>
         <module-name>Slack Alarm Notification Example</module-name>
         <module-description>Implements a Slack alarm notification type, which uses Slack's incoming webhooks to notify alarm events.</module-description>

--- a/slack-alarm-notification/pom.xml
+++ b/slack-alarm-notification/pom.xml
@@ -15,7 +15,7 @@
     </modules>
 
     <properties>
-        <ignition-platform-version>8.3.4-SNAPSHOT</ignition-platform-version>
+        <ignition-platform-version>8.3.4</ignition-platform-version>
         <ignition-sdk-version>${ignition-platform-version}</ignition-sdk-version>
         <module-name>Slack Alarm Notification Example</module-name>
         <module-description>Implements a Slack alarm notification type, which uses Slack's incoming webhooks to notify alarm events.</module-description>

--- a/slack-alarm-notification/slack-notification-gateway/src/main/java/io/ia/ignition/sdk/examples/slack/profile/SlackNotificationProfileResource.java
+++ b/slack-alarm-notification/slack-notification-gateway/src/main/java/io/ia/ignition/sdk/examples/slack/profile/SlackNotificationProfileResource.java
@@ -2,8 +2,7 @@ package io.ia.ignition.sdk.examples.slack.profile;
 
 import com.inductiveautomation.ignition.gateway.dataroutes.openapi.annotations.*;
 import com.inductiveautomation.ignition.gateway.web.nav.FormFieldType;
-
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 
 public record SlackNotificationProfileResource(
         @Nullable

--- a/user-source-profile/pom.xml
+++ b/user-source-profile/pom.xml
@@ -15,7 +15,7 @@
     </modules>
 
     <properties>
-        <ignition-platform-version>8.3.0</ignition-platform-version>
+        <ignition-platform-version>8.3.4-SNAPSHOT</ignition-platform-version>
         <ignition-sdk-version>${ignition-platform-version}</ignition-sdk-version>
         <module-name>MongoDB User Source Example</module-name>
         <module-description>Adds an example user source backed by MongoDB to Ignition.</module-description>

--- a/user-source-profile/pom.xml
+++ b/user-source-profile/pom.xml
@@ -15,7 +15,7 @@
     </modules>
 
     <properties>
-        <ignition-platform-version>8.3.4-SNAPSHOT</ignition-platform-version>
+        <ignition-platform-version>8.3.4</ignition-platform-version>
         <ignition-sdk-version>${ignition-platform-version}</ignition-sdk-version>
         <module-name>MongoDB User Source Example</module-name>
         <module-description>Adds an example user source backed by MongoDB to Ignition.</module-description>

--- a/user-source-profile/user-source-gateway/src/main/java/com/inductiveautomation/ignition/examples/usersource/mongodb/MongoDbUserSource.java
+++ b/user-source-profile/user-source-gateway/src/main/java/com/inductiveautomation/ignition/examples/usersource/mongodb/MongoDbUserSource.java
@@ -28,11 +28,11 @@ import org.apache.log4j.Level;
 import org.bson.Document;
 import org.bson.conversions.Bson;
 
-import javax.annotation.Nonnull;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import org.jspecify.annotations.NonNull;
 
 /**
  * An example implementation of a User Source Profile that uses MongoDB as the backend data store.
@@ -397,9 +397,8 @@ public class MongoDbUserSource extends AbstractUserSourceProfile {
         }
     }
 
-    @Nonnull
     @Override
-    public Collection<Role> getRoles() {
+    public @NonNull Collection<Role> getRoles() {
         Collection<Role> roles = new ArrayList<>();
         try (MongoCursor<Document> cursor = getDatabase().getCollection(COLLECTION_ROLES).find().iterator()) {
             while (cursor.hasNext()) {
@@ -685,9 +684,8 @@ public class MongoDbUserSource extends AbstractUserSourceProfile {
         collection.updateOne(filter, update);
     }
 
-    @Nonnull
     @Override
-    public Collection<User> getUsers() {
+    public @NonNull Collection<User> getUsers() {
         Collection<User> users = new ArrayList<>();
         try (MongoCursor<Document> cursor = getDatabase().getCollection(COLLECTION_USERS).find().iterator()) {
             while (cursor.hasNext()) {
@@ -697,9 +695,8 @@ public class MongoDbUserSource extends AbstractUserSourceProfile {
         return users;
     }
 
-    @Nonnull
     @Override
-    public Optional<User> getUser(String userName) {
+    public @NonNull Optional<User> getUser(String userName) {
         return Optional.ofNullable(
                 toUser(getDatabase().getCollection(COLLECTION_USERS).find(Filters.eq(KEY_NAME, userName)).first())
         );

--- a/vision-component/pom.xml
+++ b/vision-component/pom.xml
@@ -18,7 +18,7 @@
     </modules>
 
     <properties>
-        <ignition-platform-version>8.3.4-SNAPSHOT</ignition-platform-version>
+        <ignition-platform-version>8.3.4</ignition-platform-version>
         <ignition-sdk-version>${ignition-platform-version}</ignition-sdk-version>
     </properties>
 

--- a/vision-component/pom.xml
+++ b/vision-component/pom.xml
@@ -18,7 +18,7 @@
     </modules>
 
     <properties>
-        <ignition-platform-version>8.3.0</ignition-platform-version>
+        <ignition-platform-version>8.3.4-SNAPSHOT</ignition-platform-version>
         <ignition-sdk-version>${ignition-platform-version}</ignition-sdk-version>
     </properties>
 


### PR DESCRIPTION
## Summary

- Migrate nullability annotations from `javax.annotation` (`@Nullable`, `@Nonnull`) to `org.jspecify.annotations` (`@Nullable`, `@NonNull`) in the slack-alarm-notification and user-source-profile examples
- Bump Ignition platform version from 8.3.0 to 8.3.4-SNAPSHOT across all example modules