### PR TITLE
IGN-15978 - Add new goal of write-dev-descriptor to projects depend on internal maven plugin

### DIFF
--- a/event-stream-handler/README.md
+++ b/event-stream-handler/README.md
@@ -4,3 +4,21 @@ This example shows how to add a handler to the Ignition Event Stream.  The handl
 Event Stream and writes the payload to file.
 
 
+
+## Dev Mode Descriptor
+
+The build binds the `ignition-maven-plugin`'s `write-dev-descriptor` goal to the `package` phase, next to the `modl` goal:
+
+```xml
+<goals>
+    <goal>modl</goal>
+    <goal>write-dev-descriptor</goal>
+</goals>
+```
+
+Running `mvn package` then produces, in the build module's `target/` directory:
+
+* the packaged `*.modl` you install from the Gateway's `Config > Modules` page, and
+* a JSON dev descriptor at `target/dev/<moduleId>.json`.
+
+The descriptor records the module metadata (id, name, version, hooks, dependencies) along with each subproject's compiled `target/classes` directory and resolved dependency JARs, letting a development Ignition Gateway load the module straight from the Maven build outputs instead of requiring a full `.modl` install. Because it points at `target/classes`, the module must be compiled first — the `package`-phase binding ensures that. It is generated automatically by the module build, so `mvn package` (re)produces it.

--- a/event-stream-handler/event-stream-handler-build/pom.xml
+++ b/event-stream-handler/event-stream-handler-build/pom.xml
@@ -35,7 +35,7 @@
             <plugin>
                 <groupId>com.inductiveautomation.ignitionsdk</groupId>
                 <artifactId>ignition-maven-plugin</artifactId>
-                <version>1.1.0</version>
+                <version>1.2.1-SNAPSHOT</version>
 
                 <executions>
                     <execution>
@@ -43,6 +43,7 @@
                         <phase>package</phase>
                         <goals>
                             <goal>modl</goal>
+                            <goal>write-dev-descriptor</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/event-stream-handler/pom.xml
+++ b/event-stream-handler/pom.xml
@@ -37,6 +37,16 @@
                 <enabled>false</enabled>
             </snapshots>
         </pluginRepository>
+        <pluginRepository>
+            <id>ia-snapshots</id>
+            <url>https://nexus.inductiveautomation.com/repository/inductiveautomation-snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </pluginRepository>
     </pluginRepositories>
 
     <repositories>

--- a/event-stream-source/README.md
+++ b/event-stream-source/README.md
@@ -7,3 +7,21 @@ values `A`, `B`, `C`, `A`, `B`, `C` sending `A` at time 0, `B` at time 1, `C` at
 
 
 
+
+## Dev Mode Descriptor
+
+The build binds the `ignition-maven-plugin`'s `write-dev-descriptor` goal to the `package` phase, next to the `modl` goal:
+
+```xml
+<goals>
+    <goal>modl</goal>
+    <goal>write-dev-descriptor</goal>
+</goals>
+```
+
+Running `mvn package` then produces, in the build module's `target/` directory:
+
+* the packaged `*.modl` you install from the Gateway's `Config > Modules` page, and
+* a JSON dev descriptor at `target/dev/<moduleId>.json`.
+
+The descriptor records the module metadata (id, name, version, hooks, dependencies) along with each subproject's compiled `target/classes` directory and resolved dependency JARs, letting a development Ignition Gateway load the module straight from the Maven build outputs instead of requiring a full `.modl` install. Because it points at `target/classes`, the module must be compiled first — the `package`-phase binding ensures that. It is generated automatically by the module build, so `mvn package` (re)produces it.

--- a/event-stream-source/event-stream-source-build/pom.xml
+++ b/event-stream-source/event-stream-source-build/pom.xml
@@ -35,7 +35,7 @@
             <plugin>
                 <groupId>com.inductiveautomation.ignitionsdk</groupId>
                 <artifactId>ignition-maven-plugin</artifactId>
-                <version>1.1.0</version>
+                <version>1.2.1-SNAPSHOT</version>
 
                 <executions>
                     <execution>
@@ -43,6 +43,7 @@
                         <phase>package</phase>
                         <goals>
                             <goal>modl</goal>
+                            <goal>write-dev-descriptor</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/event-stream-source/pom.xml
+++ b/event-stream-source/pom.xml
@@ -37,6 +37,16 @@
                 <enabled>false</enabled>
             </snapshots>
         </pluginRepository>
+        <pluginRepository>
+            <id>ia-snapshots</id>
+            <url>https://nexus.inductiveautomation.com/repository/inductiveautomation-snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </pluginRepository>
     </pluginRepositories>
 
     <repositories>

--- a/expression-function/README.md
+++ b/expression-function/README.md
@@ -10,3 +10,21 @@ Click on the label's Text 'Bind Property' button.
 In the Property Binding window, select the Expression option and add `exampleMultiply(4, 6)` to the window.
 Click OK.
 The label will now use the custom expression as its text.
+
+## Dev Mode Descriptor
+
+The build binds the `ignition-maven-plugin`'s `write-dev-descriptor` goal to the `package` phase, next to the `modl` goal:
+
+```xml
+<goals>
+    <goal>modl</goal>
+    <goal>write-dev-descriptor</goal>
+</goals>
+```
+
+Running `mvn package` then produces, in the build module's `target/` directory:
+
+* the packaged `*.modl` you install from the Gateway's `Config > Modules` page, and
+* a JSON dev descriptor at `target/dev/<moduleId>.json`.
+
+The descriptor records the module metadata (id, name, version, hooks, dependencies) along with each subproject's compiled `target/classes` directory and resolved dependency JARs, letting a development Ignition Gateway load the module straight from the Maven build outputs instead of requiring a full `.modl` install. Because it points at `target/classes`, the module must be compiled first — the `package`-phase binding ensures that. It is generated automatically by the module build, so `mvn package` (re)produces it.

--- a/expression-function/expression-function-build/pom.xml
+++ b/expression-function/expression-function-build/pom.xml
@@ -40,13 +40,14 @@
             <plugin>
                 <groupId>com.inductiveautomation.ignitionsdk</groupId>
                 <artifactId>ignition-maven-plugin</artifactId>
-                <version>1.1.0</version>
+                <version>1.2.1-SNAPSHOT</version>
 
                 <executions>
                     <execution>
                         <phase>package</phase>
                         <goals>
                             <goal>modl</goal>
+                            <goal>write-dev-descriptor</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/expression-function/pom.xml
+++ b/expression-function/pom.xml
@@ -31,6 +31,16 @@
             <id>releases</id>
             <url>https://nexus.inductiveautomation.com/repository/inductiveautomation-releases</url>
         </pluginRepository>
+        <pluginRepository>
+            <id>ia-snapshots</id>
+            <url>https://nexus.inductiveautomation.com/repository/inductiveautomation-snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </pluginRepository>
     </pluginRepositories>
 
     <repositories>

--- a/gateway-network-function/README.md
+++ b/gateway-network-function/README.md
@@ -85,3 +85,21 @@ If you call the `system.example.gn.getRemoteLogEntries()` script function, one o
 ```
 Encoding job 365 service response 'CallResult:GetLogsService/getLogEvents': header='{ "intentName": "_rpc:355|0", "codecName": "_svcres_", "headersValues": { "_headerid_": "e42a75f4-81bd-4430-9545-ebfc4713fd58", "_source_": "_0:0:agent", "_ver_": "2" } }', data='{ "body": { "@type": "type.googleapis.com/metro.protobuf.ServiceResponsePB", "result": { "@type": "type.googleapis.com/metro.protobuf.ListPB", "listType": "List_ArrayList", "items": [{ "@type": "type.googleapis.com/getlogs.protobuf.LogEventPB", "timestamp": "1741183729192",.....
 ```
+
+## Dev Mode Descriptor
+
+The build binds the `ignition-maven-plugin`'s `write-dev-descriptor` goal to the `package` phase, next to the `modl` goal:
+
+```xml
+<goals>
+    <goal>modl</goal>
+    <goal>write-dev-descriptor</goal>
+</goals>
+```
+
+Running `mvn package` then produces, in the build module's `target/` directory:
+
+* the packaged `*.modl` you install from the Gateway's `Config > Modules` page, and
+* a JSON dev descriptor at `target/dev/<moduleId>.json`.
+
+The descriptor records the module metadata (id, name, version, hooks, dependencies) along with each subproject's compiled `target/classes` directory and resolved dependency JARs, letting a development Ignition Gateway load the module straight from the Maven build outputs instead of requiring a full `.modl` install. Because it points at `target/classes`, the module must be compiled first — the `package`-phase binding ensures that. It is generated automatically by the module build, so `mvn package` (re)produces it.

--- a/gateway-network-function/gateway-network-function-build/pom.xml
+++ b/gateway-network-function/gateway-network-function-build/pom.xml
@@ -47,13 +47,14 @@
             <plugin>
                 <groupId>com.inductiveautomation.ignitionsdk</groupId>
                 <artifactId>ignition-maven-plugin</artifactId>
-                <version>1.1.0</version>
+                <version>1.2.1-SNAPSHOT</version>
 
                 <executions>
                     <execution>
                         <phase>package</phase>
                         <goals>
                             <goal>modl</goal>
+                            <goal>write-dev-descriptor</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/gateway-network-function/pom.xml
+++ b/gateway-network-function/pom.xml
@@ -38,6 +38,16 @@
                 <enabled>false</enabled>
             </snapshots>
         </pluginRepository>
+        <pluginRepository>
+            <id>ia-snapshots</id>
+            <url>https://nexus.inductiveautomation.com/repository/inductiveautomation-snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </pluginRepository>
     </pluginRepositories>
 
     <repositories>

--- a/managed-tag-provider/README.md
+++ b/managed-tag-provider/README.md
@@ -1,3 +1,21 @@
 # Managed Tag Provider
 
 Sets up the scaffolding for a simple implementation of the 8.3+ `ManagedTagProvider` interface. In the `GatewayHook`,  `setup` creates a new provider, which is then used to expose some read-only tags, and a single writeable tag.
+
+## Dev Mode Descriptor
+
+The build binds the `ignition-maven-plugin`'s `write-dev-descriptor` goal to the `package` phase, next to the `modl` goal:
+
+```xml
+<goals>
+    <goal>modl</goal>
+    <goal>write-dev-descriptor</goal>
+</goals>
+```
+
+Running `mvn package` then produces, in the build module's `target/` directory:
+
+* the packaged `*.modl` you install from the Gateway's `Config > Modules` page, and
+* a JSON dev descriptor at `target/dev/<moduleId>.json`.
+
+The descriptor records the module metadata (id, name, version, hooks, dependencies) along with each subproject's compiled `target/classes` directory and resolved dependency JARs, letting a development Ignition Gateway load the module straight from the Maven build outputs instead of requiring a full `.modl` install. Because it points at `target/classes`, the module must be compiled first — the `package`-phase binding ensures that. It is generated automatically by the module build, so `mvn package` (re)produces it.

--- a/managed-tag-provider/managed-tag-provider-build/pom.xml
+++ b/managed-tag-provider/managed-tag-provider-build/pom.xml
@@ -25,13 +25,14 @@
             <plugin>
                 <groupId>com.inductiveautomation.ignitionsdk</groupId>
                 <artifactId>ignition-maven-plugin</artifactId>
-                <version>1.1.0</version>
+                <version>1.2.1-SNAPSHOT</version>
 
                 <executions>
                     <execution>
                         <phase>package</phase>
                         <goals>
                             <goal>modl</goal>
+                            <goal>write-dev-descriptor</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/managed-tag-provider/pom.xml
+++ b/managed-tag-provider/pom.xml
@@ -35,6 +35,16 @@
                 <enabled>false</enabled>
             </snapshots>
         </pluginRepository>
+        <pluginRepository>
+            <id>ia-snapshots</id>
+            <url>https://nexus.inductiveautomation.com/repository/inductiveautomation-snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </pluginRepository>
     </pluginRepositories>
 
     <repositories>

--- a/opc-ua-device/README.md
+++ b/opc-ua-device/README.md
@@ -8,3 +8,21 @@ Provides the scaffolding to create a device driver that will register nodes (tag
 `ExampleDeviceType` overrides `DeviceType` to provide a new `createDevice` implementation, which will return a new `ExampleDevice`.
 That device is created using an `ExampleDeviceSettings` record, which in this case only contains one 'custom' field - the number of tags to create per folder.
 `ExampleDevice` implements the `Device` interface. Most of the methods should be fairly self explanatory - a few (`onDataItemsCreated`, etc are delegated to a `SubscriptionModel` that comes from [Milo](https://github.com/eclipse/milo), the open-source OPC-UA server backing Ignition's UA server.)
+
+## Dev Mode Descriptor
+
+The build binds the `ignition-maven-plugin`'s `write-dev-descriptor` goal to the `package` phase, next to the `modl` goal:
+
+```xml
+<goals>
+    <goal>modl</goal>
+    <goal>write-dev-descriptor</goal>
+</goals>
+```
+
+Running `mvn package` then produces, in the build module's `target/` directory:
+
+* the packaged `*.modl` you install from the Gateway's `Config > Modules` page, and
+* a JSON dev descriptor at `target/dev/<moduleId>.json`.
+
+The descriptor records the module metadata (id, name, version, hooks, dependencies) along with each subproject's compiled `target/classes` directory and resolved dependency JARs, letting a development Ignition Gateway load the module straight from the Maven build outputs instead of requiring a full `.modl` install. Because it points at `target/classes`, the module must be compiled first — the `package`-phase binding ensures that. It is generated automatically by the module build, so `mvn package` (re)produces it.

--- a/opc-ua-device/opc-ua-device-build/pom.xml
+++ b/opc-ua-device/opc-ua-device-build/pom.xml
@@ -25,13 +25,14 @@
             <plugin>
                 <groupId>com.inductiveautomation.ignitionsdk</groupId>
                 <artifactId>ignition-maven-plugin</artifactId>
-                <version>1.2.0</version>
+                <version>1.2.1-SNAPSHOT</version>
 
                 <executions>
                     <execution>
                         <phase>package</phase>
                         <goals>
                             <goal>modl</goal>
+                            <goal>write-dev-descriptor</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/opc-ua-device/pom.xml
+++ b/opc-ua-device/pom.xml
@@ -35,6 +35,16 @@
                 <enabled>false</enabled>
             </snapshots>
         </pluginRepository>
+        <pluginRepository>
+            <id>ia-snapshots</id>
+            <url>https://nexus.inductiveautomation.com/repository/inductiveautomation-snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </pluginRepository>
     </pluginRepositories>
 
     <repositories>

--- a/report-component/README.md
+++ b/report-component/README.md
@@ -19,3 +19,21 @@ The Reporting API provides a simple process to add Shapes, but there are a few t
     in your Designer hook startup.
 
 
+
+## Dev Mode Descriptor
+
+The build binds the `ignition-maven-plugin`'s `write-dev-descriptor` goal to the `package` phase, next to the `modl` goal:
+
+```xml
+<goals>
+    <goal>modl</goal>
+    <goal>write-dev-descriptor</goal>
+</goals>
+```
+
+Running `mvn package` then produces, in the build module's `target/` directory:
+
+* the packaged `*.modl` you install from the Gateway's `Config > Modules` page, and
+* a JSON dev descriptor at `target/dev/<moduleId>.json`.
+
+The descriptor records the module metadata (id, name, version, hooks, dependencies) along with each subproject's compiled `target/classes` directory and resolved dependency JARs, letting a development Ignition Gateway load the module straight from the Maven build outputs instead of requiring a full `.modl` install. Because it points at `target/classes`, the module must be compiled first — the `package`-phase binding ensures that. It is generated automatically by the module build, so `mvn package` (re)produces it.

--- a/report-component/pom.xml
+++ b/report-component/pom.xml
@@ -37,6 +37,16 @@
                 <enabled>false</enabled>
             </snapshots>
         </pluginRepository>
+        <pluginRepository>
+            <id>ia-snapshots</id>
+            <url>https://nexus.inductiveautomation.com/repository/inductiveautomation-snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </pluginRepository>
     </pluginRepositories>
 
     <repositories>

--- a/report-component/report-component-build/pom.xml
+++ b/report-component/report-component-build/pom.xml
@@ -35,7 +35,7 @@
             <plugin>
                 <groupId>com.inductiveautomation.ignitionsdk</groupId>
                 <artifactId>ignition-maven-plugin</artifactId>
-                <version>1.1.0</version>
+                <version>1.2.1-SNAPSHOT</version>
 
                 <executions>
                     <execution>
@@ -43,6 +43,7 @@
                         <phase>package</phase>
                         <goals>
                             <goal>modl</goal>
+                            <goal>write-dev-descriptor</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/report-datasource/README.md
+++ b/report-datasource/README.md
@@ -17,3 +17,21 @@ The Reporting API provides a simple process to add DataSources.  It requires a f
 The `DataSource` itself simply provides a way to add to the existing `Map<String, Object>`.  While there may be some
 flexibility in the structure of the Data that the reporting engine can handle, it is recommended that Datasets
 (`com.inductiveautomation.ignition.common.Dataset`) are used for compatibility.
+
+## Dev Mode Descriptor
+
+The build binds the `ignition-maven-plugin`'s `write-dev-descriptor` goal to the `package` phase, next to the `modl` goal:
+
+```xml
+<goals>
+    <goal>modl</goal>
+    <goal>write-dev-descriptor</goal>
+</goals>
+```
+
+Running `mvn package` then produces, in the build module's `target/` directory:
+
+* the packaged `*.modl` you install from the Gateway's `Config > Modules` page, and
+* a JSON dev descriptor at `target/dev/<moduleId>.json`.
+
+The descriptor records the module metadata (id, name, version, hooks, dependencies) along with each subproject's compiled `target/classes` directory and resolved dependency JARs, letting a development Ignition Gateway load the module straight from the Maven build outputs instead of requiring a full `.modl` install. Because it points at `target/classes`, the module must be compiled first — the `package`-phase binding ensures that. It is generated automatically by the module build, so `mvn package` (re)produces it.

--- a/report-datasource/pom.xml
+++ b/report-datasource/pom.xml
@@ -78,5 +78,15 @@
                 <enabled>false</enabled>
             </snapshots>
         </pluginRepository>
+        <pluginRepository>
+            <id>ia-snapshots</id>
+            <url>https://nexus.inductiveautomation.com/repository/inductiveautomation-snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </pluginRepository>
     </pluginRepositories>
 </project>

--- a/report-datasource/report-datasource-build/pom.xml
+++ b/report-datasource/report-datasource-build/pom.xml
@@ -35,7 +35,7 @@
             <plugin>
                 <groupId>com.inductiveautomation.ignitionsdk</groupId>
                 <artifactId>ignition-maven-plugin</artifactId>
-                <version>1.1.0</version>
+                <version>1.2.1-SNAPSHOT</version>
 
                 <executions>
                     <execution>
@@ -43,6 +43,7 @@
                         <phase>package</phase>
                         <goals>
                             <goal>modl</goal>
+                            <goal>write-dev-descriptor</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/scripting-function/README.md
+++ b/scripting-function/README.md
@@ -19,3 +19,21 @@ interface method on the Gateway, adapting parameters and return types using the 
 
 In this way, the proxy handles the "heavy lifting" of passing values back and forth between scopes, and the serialization
 and deserialization of values is decoupled from the actual interface methods and implementations.
+
+## Dev Mode Descriptor
+
+The build binds the `ignition-maven-plugin`'s `write-dev-descriptor` goal to the `package` phase, next to the `modl` goal:
+
+```xml
+<goals>
+    <goal>modl</goal>
+    <goal>write-dev-descriptor</goal>
+</goals>
+```
+
+Running `mvn package` then produces, in the build module's `target/` directory:
+
+* the packaged `*.modl` you install from the Gateway's `Config > Modules` page, and
+* a JSON dev descriptor at `target/dev/<moduleId>.json`.
+
+The descriptor records the module metadata (id, name, version, hooks, dependencies) along with each subproject's compiled `target/classes` directory and resolved dependency JARs, letting a development Ignition Gateway load the module straight from the Maven build outputs instead of requiring a full `.modl` install. Because it points at `target/classes`, the module must be compiled first — the `package`-phase binding ensures that. It is generated automatically by the module build, so `mvn package` (re)produces it.

--- a/scripting-function/pom.xml
+++ b/scripting-function/pom.xml
@@ -38,6 +38,16 @@
                 <enabled>false</enabled>
             </snapshots>
         </pluginRepository>
+        <pluginRepository>
+            <id>ia-snapshots</id>
+            <url>https://nexus.inductiveautomation.com/repository/inductiveautomation-snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </pluginRepository>
     </pluginRepositories>
 
     <repositories>

--- a/scripting-function/scripting-function-build/pom.xml
+++ b/scripting-function/scripting-function-build/pom.xml
@@ -39,7 +39,7 @@
             <plugin>
                 <groupId>com.inductiveautomation.ignitionsdk</groupId>
                 <artifactId>ignition-maven-plugin</artifactId>
-                <version>1.1.0</version>
+                <version>1.2.1-SNAPSHOT</version>
 
                 <executions>
                     <execution>
@@ -47,6 +47,7 @@
                         <phase>package</phase>
                         <goals>
                             <goal>modl</goal>
+                            <goal>write-dev-descriptor</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/secret-provider/README.md
+++ b/secret-provider/README.md
@@ -81,3 +81,21 @@ secrets_db> db.mycollection.insertOne({
    }
  })
 ```
+
+## Dev Mode Descriptor
+
+The build binds the `ignition-maven-plugin`'s `write-dev-descriptor` goal to the `package` phase, next to the `modl` goal:
+
+```xml
+<goals>
+    <goal>modl</goal>
+    <goal>write-dev-descriptor</goal>
+</goals>
+```
+
+Running `mvn package` then produces, in the build module's `target/` directory:
+
+* the packaged `*.modl` you install from the Gateway's `Config > Modules` page, and
+* a JSON dev descriptor at `target/dev/<moduleId>.json`.
+
+The descriptor records the module metadata (id, name, version, hooks, dependencies) along with each subproject's compiled `target/classes` directory and resolved dependency JARs, letting a development Ignition Gateway load the module straight from the Maven build outputs instead of requiring a full `.modl` install. Because it points at `target/classes`, the module must be compiled first — the `package`-phase binding ensures that. It is generated automatically by the module build, so `mvn package` (re)produces it.

--- a/secret-provider/pom.xml
+++ b/secret-provider/pom.xml
@@ -35,6 +35,16 @@
                 <enabled>false</enabled>
             </snapshots>
         </pluginRepository>
+        <pluginRepository>
+            <id>ia-snapshots</id>
+            <url>https://nexus.inductiveautomation.com/repository/inductiveautomation-snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </pluginRepository>
     </pluginRepositories>
 
     <repositories>

--- a/secret-provider/secret-provider-build/pom.xml
+++ b/secret-provider/secret-provider-build/pom.xml
@@ -24,13 +24,14 @@
             <plugin>
                 <groupId>com.inductiveautomation.ignitionsdk</groupId>
                 <artifactId>ignition-maven-plugin</artifactId>
-                <version>1.2.0</version>
+                <version>1.2.1-SNAPSHOT</version>
 
                 <executions>
                     <execution>
                         <phase>package</phase>
                         <goals>
                             <goal>modl</goal>
+                            <goal>write-dev-descriptor</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/slack-alarm-notification/README.md
+++ b/slack-alarm-notification/README.md
@@ -55,3 +55,21 @@ the following JSON object to the `"contactInfos"` array:
     ```
 
 3. Restart the Gateway to apply the changes.
+
+## Dev Mode Descriptor
+
+The build binds the `ignition-maven-plugin`'s `write-dev-descriptor` goal to the `package` phase, next to the `modl` goal:
+
+```xml
+<goals>
+    <goal>modl</goal>
+    <goal>write-dev-descriptor</goal>
+</goals>
+```
+
+Running `mvn package` then produces, in the build module's `target/` directory:
+
+* the packaged `*.modl` you install from the Gateway's `Config > Modules` page, and
+* a JSON dev descriptor at `target/dev/<moduleId>.json`.
+
+The descriptor records the module metadata (id, name, version, hooks, dependencies) along with each subproject's compiled `target/classes` directory and resolved dependency JARs, letting a development Ignition Gateway load the module straight from the Maven build outputs instead of requiring a full `.modl` install. Because it points at `target/classes`, the module must be compiled first — the `package`-phase binding ensures that. It is generated automatically by the module build, so `mvn package` (re)produces it.

--- a/slack-alarm-notification/pom.xml
+++ b/slack-alarm-notification/pom.xml
@@ -35,6 +35,16 @@
                 <enabled>false</enabled>
             </snapshots>
         </pluginRepository>
+        <pluginRepository>
+            <id>ia-snapshots</id>
+            <url>https://nexus.inductiveautomation.com/repository/inductiveautomation-snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </pluginRepository>
     </pluginRepositories>
 
     <repositories>

--- a/slack-alarm-notification/slack-notification-build/pom.xml
+++ b/slack-alarm-notification/slack-notification-build/pom.xml
@@ -24,13 +24,14 @@
             <plugin>
                 <groupId>com.inductiveautomation.ignitionsdk</groupId>
                 <artifactId>ignition-maven-plugin</artifactId>
-                <version>1.1.0</version>
+                <version>1.2.1-SNAPSHOT</version>
 
                 <executions>
                     <execution>
                         <phase>package</phase>
                         <goals>
                             <goal>modl</goal>
+                            <goal>write-dev-descriptor</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/user-source-profile/README.md
+++ b/user-source-profile/README.md
@@ -24,3 +24,21 @@ docker run -d -p 27017:27017 --rm --name secure-mongo \
   -e MONGO_INITDB_ROOT_PASSWORD=secret \
   mongo
 ```
+
+## Dev Mode Descriptor
+
+The build binds the `ignition-maven-plugin`'s `write-dev-descriptor` goal to the `package` phase, next to the `modl` goal:
+
+```xml
+<goals>
+    <goal>modl</goal>
+    <goal>write-dev-descriptor</goal>
+</goals>
+```
+
+Running `mvn package` then produces, in the build module's `target/` directory:
+
+* the packaged `*.modl` you install from the Gateway's `Config > Modules` page, and
+* a JSON dev descriptor at `target/dev/<moduleId>.json`.
+
+The descriptor records the module metadata (id, name, version, hooks, dependencies) along with each subproject's compiled `target/classes` directory and resolved dependency JARs, letting a development Ignition Gateway load the module straight from the Maven build outputs instead of requiring a full `.modl` install. Because it points at `target/classes`, the module must be compiled first — the `package`-phase binding ensures that. It is generated automatically by the module build, so `mvn package` (re)produces it.

--- a/user-source-profile/pom.xml
+++ b/user-source-profile/pom.xml
@@ -35,6 +35,16 @@
                 <enabled>false</enabled>
             </snapshots>
         </pluginRepository>
+        <pluginRepository>
+            <id>ia-snapshots</id>
+            <url>https://nexus.inductiveautomation.com/repository/inductiveautomation-snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </pluginRepository>
     </pluginRepositories>
 
     <repositories>

--- a/user-source-profile/user-source-build/pom.xml
+++ b/user-source-profile/user-source-build/pom.xml
@@ -24,13 +24,14 @@
             <plugin>
                 <groupId>com.inductiveautomation.ignitionsdk</groupId>
                 <artifactId>ignition-maven-plugin</artifactId>
-                <version>1.2.0</version>
+                <version>1.2.1-SNAPSHOT</version>
 
                 <executions>
                     <execution>
                         <phase>package</phase>
                         <goals>
                             <goal>modl</goal>
+                            <goal>write-dev-descriptor</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/vision-component/README.md
+++ b/vision-component/README.md
@@ -1,3 +1,21 @@
 # Vision Component Example
 
 Adds a simple component to the Vision module.
+
+## Dev Mode Descriptor
+
+The build binds the `ignition-maven-plugin`'s `write-dev-descriptor` goal to the `package` phase, next to the `modl` goal:
+
+```xml
+<goals>
+    <goal>modl</goal>
+    <goal>write-dev-descriptor</goal>
+</goals>
+```
+
+Running `mvn package` then produces, in the build module's `target/` directory:
+
+* the packaged `*.modl` you install from the Gateway's `Config > Modules` page, and
+* a JSON dev descriptor at `target/dev/<moduleId>.json`.
+
+The descriptor records the module metadata (id, name, version, hooks, dependencies) along with each subproject's compiled `target/classes` directory and resolved dependency JARs, letting a development Ignition Gateway load the module straight from the Maven build outputs instead of requiring a full `.modl` install. Because it points at `target/classes`, the module must be compiled first — the `package`-phase binding ensures that. It is generated automatically by the module build, so `mvn package` (re)produces it.

--- a/vision-component/ce-build/pom.xml
+++ b/vision-component/ce-build/pom.xml
@@ -30,13 +30,14 @@
             <plugin>
                 <groupId>com.inductiveautomation.ignitionsdk</groupId>
                 <artifactId>ignition-maven-plugin</artifactId>
-                <version>1.1.0</version>
+                <version>1.2.1-SNAPSHOT</version>
 
                 <executions>
                     <execution>
                         <phase>package</phase>
                         <goals>
                             <goal>modl</goal>
+                            <goal>write-dev-descriptor</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/vision-component/pom.xml
+++ b/vision-component/pom.xml
@@ -34,6 +34,16 @@
                 <enabled>false</enabled>
             </snapshots>
         </pluginRepository>
+        <pluginRepository>
+            <id>ia-snapshots</id>
+            <url>https://nexus.inductiveautomation.com/repository/inductiveautomation-snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </pluginRepository>
     </pluginRepositories>
 
     <repositories>


### PR DESCRIPTION
This is the downstream change of [ignition-maven-plugin PR](https://github.com/inductiveautomation/ignition-maven-plugin/pull/9), and affected 13 projects that have this plugin applied.

* Add a new goal' write-dev-descriptor' to package phase
* Update README.md file with instructions on working with this new goal
* Update pom.xml to use maven plugin 1.2.1

Fixes: IGN-15978