### PR TITLE
Upgrade perspective/webui Gradle examples to io.ia.sdk.modl 0.5.0

### DIFF
--- a/perspective-component-minimal/build.gradle.kts
+++ b/perspective-component-minimal/build.gradle.kts
@@ -4,7 +4,7 @@ import io.ia.sdk.gradle.modl.task.Deploy
 plugins {
     base
     // the ignition module plugin: https://github.com/inductiveautomation/ignition-module-tools
-    id("io.ia.sdk.modl") version("0.1.1")
+    id("io.ia.sdk.modl") version("0.5.0")
 }
 
 allprojects {
@@ -27,14 +27,15 @@ ignitionModule {
     freeModule.set(true)
     license.set("license.html")
 
-    // If we depend on other module being loaded/available, then we specify IDs of the module we depend on,
-    // and specify the Ignition Scope(s) that apply. "G" for gateway, "D" for designer, "C" for VISION client
-    // (this module does not run in the scope of a Vision client, so we don't need a "C" entry here)
-    moduleDependencies.putAll(
-        mapOf(
-            "com.inductiveautomation.perspective" to "GD"
-        )
-    )
+    // Module dependencies for Ignition 8.3+: use moduleDependencySpecs (not the deprecated
+    // moduleDependencies map). "G" = gateway, "D" = designer, "C" = Vision client.
+    // (this module does not run in Vision client scope, so no "C" entry)
+    moduleDependencySpecs {
+        register("com.inductiveautomation.perspective") {
+            scope = "GD"
+            required = true
+        }
+    }
 
     // map of 'Gradle Project Path' to Ignition Scope in which the project is relevant.  This is is combined with
     // the dependency declarations within the subproject's build.gradle.kts in order to determine which

--- a/perspective-component/build.gradle.kts
+++ b/perspective-component/build.gradle.kts
@@ -4,7 +4,7 @@ import java.util.concurrent.TimeUnit
 plugins {
     base
     // the ignition module plugin: https://github.com/inductiveautomation/ignition-module-tools
-    id("io.ia.sdk.modl") version("0.1.1")
+    id("io.ia.sdk.modl") version("0.5.0")
     id("org.barfuin.gradle.taskinfo") version "2.1.0"
 }
 
@@ -23,12 +23,18 @@ ignitionModule {
     moduleVersion.set("${project.version}")
     moduleDescription.set("A module that adds components to the Perspective module.")
     requiredIgnitionVersion.set("8.3.0")
+    requiredFrameworkVersion.set("8")
     license.set("license.html")
 
-    // If we depend on other module being loaded/available, then we specify IDs of the module we depend on,
-    // and specify the Ignition Scope that applies. "G" for gateway, "D" for designer, "C" for VISION client
-    // (this module does not run in the scope of a Vision client, so we don't need a "C" entry here)
-    moduleDependencies.put("com.inductiveautomation.perspective", "DG")
+    // Module dependencies for Ignition 8.3+: use moduleDependencySpecs (not the deprecated
+    // moduleDependencies map). "G" = gateway, "D" = designer, "C" = Vision client.
+    // (this module does not run in Vision client scope, so no "C" entry)
+    moduleDependencySpecs {
+        register("com.inductiveautomation.perspective") {
+            scope = "DG"
+            required = true
+        }
+    }
 
     // map of 'Gradle Project Path' to Ignition Scope in which the project is relevant.  This is is combined with
     // the dependency declarations within the subproject's build.gradle.kts in order to determine which

--- a/webui-webpage/build.gradle.kts
+++ b/webui-webpage/build.gradle.kts
@@ -8,7 +8,7 @@
  */
 
 plugins {
-    id("io.ia.sdk.modl") version("0.1.1")
+    id("io.ia.sdk.modl") version("0.5.0")
 }
 
 val sdk_version by extra("8.3.0")
@@ -57,17 +57,6 @@ ignitionModule {
     ))
 
     /*
-     * Add your module dependencies here, following the examples, with scope being one or more of G, C or D,
-     * for (G)ateway, (D)esigner, Vision (C)lient.
-     * Example:
-     * moduleDependencies = mapOf(
-     *    "CD" to "com.inductiveautomation.vision",
-     *    "G" to "com.inductiveautomation.opcua"
-     *  )
-     */
-    moduleDependencies.set(mapOf<String, String>())
-
-    /*
      * Add required module dependencies here, following the examples, with scope being one or more of G, C or D,
      * for (G)ateway, (D)esigner, Vision (C)lient.
      *
@@ -80,14 +69,16 @@ ignitionModule {
      *      // register("com.another.mod") { ...
      *   }
      *
-     * If any of module's required module dependencies are not present, the
+     * If any of the module's required module dependencies are not present, the
      * gateway will fault on loading the module.
      *
-     * NOTE: For modules targeting Ignition 8.3 and later. Use `moduleDependencies` for 8.1 and earlier.
-     * This property will only add the "required" flag if {requiredIgnitionVersion} is at least 8.3
+     * NOTE: For modules targeting Ignition 8.3 and later, use moduleDependencySpecs.
+     * Use the deprecated `moduleDependencies` map only for 8.1 and earlier.
+     * The "required" flag is honored when requiredIgnitionVersion is at least 8.3.
      *
+     * This example has no module-level dependencies beyond the platform.
      */
-    //moduleDependencySpecs { }
+    // moduleDependencySpecs { }
 
     /*
      * Map of fully qualified hook class to the shorthand scope.  Only one scope may apply to a class, and each scope


### PR DESCRIPTION
## Summary

Fixes #119 by upgrading the Perspective component examples (and webui-webpage) from `io.ia.sdk.modl` **0.1.1** to **0.5.0**, matching the pattern already used by `immutable-project`.

### Changes
| Project | Plugin | Module deps |
|---------|--------|-------------|
| `perspective-component/` | 0.1.1 → **0.5.0** | `moduleDependencies.put` → `moduleDependencySpecs { register(...) }` |
| `perspective-component-minimal/` | 0.1.1 → **0.5.0** | same migration |
| `webui-webpage/` | 0.1.1 → **0.5.0** | removed empty deprecated `moduleDependencies` map; docs note 8.3 API |

Also set `requiredFrameworkVersion = "8"` on the full perspective-component example for consistency with the other 8.3 examples.

### Migration notes (`moduleDependencySpecs`)

For modules targeting **Ignition 8.3+**, prefer `moduleDependencySpecs` over the deprecated `moduleDependencies` map. The newer API supports the `required` flag (gateway faults if the dependency module is missing).

**Before (0.1.1 / pre-8.3 style):**
```kotlin
moduleDependencies.put("com.inductiveautomation.perspective", "DG")
// or
moduleDependencies.putAll(mapOf("com.inductiveautomation.perspective" to "GD"))
```

**After (0.5.0 / 8.3 style, same as `immutable-project`):**
```kotlin
moduleDependencySpecs {
    register("com.inductiveautomation.perspective") {
        scope = "DG" // G=gateway, D=designer, C=Vision client
        required = true
    }
}
```

Gradle wrappers were already on **8.2.1** for these projects (plugin 0.5.0 uses `SyncSpec` via `project.sync` in `CollectModlDependencies`; that API needs a modern Gradle). With 8.2.1 + 0.5.0, applying the plugin alongside subprojects that use `java-library` configures cleanly—the failure mode reported in #119 (`Could not generate a decorated class for type CollectModlDependencies` / missing `SyncSpec`) does not reproduce.

### Related issues

- **#134 (Jetty 12 / servlet packages):** Already resolved on `ignition-8.3`—`perspective-component-minimal` and `perspective-component` use `jakarta.servlet` and `requiredIgnitionVersion` **8.3.0**. This PR does not change those imports; verified only.
- **#96 (zipModule not picking up Java/resource changes):** Plugin versions after 0.1.1 improved `collectModlDependencies` inputs (jar via `@InputFile`). After this upgrade, changing `common/src/main/resources/*` correctly re-runs `processResources` → `jar` → `collectModlDependencies` → `zipModule` in the minimal example. Not claiming a full close of #96 without broader repro, but the upgrade addresses the likely plugin-side root cause.

## Validation

```
export JAVA_HOME=…/openjdk@17   # Java 17 toolchain

cd perspective-component-minimal && ./gradlew help tasks --all   # BUILD SUCCESSFUL
cd perspective-component-minimal && ./gradlew zipModule          # produces OneComponent.unsigned.modl
# module.xml includes:
#   <depends scope="GD" required="true">com.inductiveautomation.perspective</depends>

cd perspective-component && ./gradlew help                       # BUILD SUCCESSFUL
cd perspective-component && ./gradlew tasks --group="Ignition Module"

cd webui-webpage && ./gradlew help                               # BUILD SUCCESSFUL
```

`skipModlSigning` remains `true` (unsigned `.modl` for local/dev use).

## AI disclosure

This contribution was prepared with assistance from an AI coding agent (Grok / xAI). Changes were reviewed and validated locally (Gradle configure + `zipModule` on the minimal example) before opening this PR.